### PR TITLE
A confirmation dialog before user close multi-tab lxterminal

### DIFF
--- a/src/lxterminal.c
+++ b/src/lxterminal.c
@@ -75,6 +75,7 @@ static void terminal_about_activate_event(GtkAction * action, LXTerminal * termi
 /* Window creation, destruction, and control. */
 static void terminal_switch_page_event(GtkNotebook * notebook, GtkWidget * page, guint num, LXTerminal * terminal);
 static void terminal_window_title_changed_event(GtkWidget * vte, Term * term);
+static gboolean terminal_close_window_confirmation_event(GtkWidget * widget, GdkEventButton * event, LXTerminal * terminal);
 static void terminal_window_exit(LXTerminal * terminal, GObject * where_the_object_was);
 #if VTE_CHECK_VERSION (0, 38, 0)
 static void terminal_child_exited_event(VteTerminal * vte, gint status, Term * term);
@@ -450,11 +451,32 @@ static void terminal_close_tab_activate_event(GtkAction * action, LXTerminal * t
  * Close the current window. */
 static void terminal_close_window_activate_event(GtkAction * action, LXTerminal * terminal)
 {
-    /* Play it safe and delete tabs one by one. */
-    while(terminal->terms->len > 0)
-    {
-        terminal_close_button_event(NULL, g_ptr_array_index(terminal->terms, 0));
-    }
+	int close_flag = 0;
+	if (terminal->terms->len > 1)
+	{
+		GtkWidget * dialog = gtk_message_dialog_new(
+				GTK_WIDGET(terminal->window), GTK_DIALOG_MODAL, GTK_MESSAGE_QUESTION, GTK_BUTTONS_YES_NO,
+				"You are about to close %d tabs. Are you sure you want to continue?", terminal->terms->len);
+		gtk_window_set_title(GTK_WINDOW(dialog), "Confirm close");
+		gint result = gtk_dialog_run(GTK_DIALOG(dialog));
+		gtk_widget_destroy(dialog);
+		if (result == GTK_RESPONSE_YES)
+		{
+			close_flag = 1;
+		}
+	}
+	else
+	{
+		close_flag = 1;
+	}
+	if (close_flag)
+	{
+		/* Play it safe and delete tabs one by one. */
+		while(terminal->terms->len > 0)
+		{
+			terminal_close_button_event(NULL, g_ptr_array_index(terminal->terms, 0));
+		}
+	}
 }
 
 /* Handler for the "Copy URL" right-click menu item.
@@ -806,6 +828,34 @@ static void terminal_window_title_changed_event(GtkWidget * vte, Term * term)
     }
 }
 
+/* Handler for "delete-event" signal on a LXTerminal. */
+static gboolean terminal_close_window_confirmation_event(GtkWidget * widget, GdkEventButton * event, LXTerminal * terminal)
+{
+	int close_flag = 0;
+	if (terminal->terms->len > 1)
+	{
+		GtkWidget * dialog = gtk_message_dialog_new(
+				GTK_WIDGET(terminal->window), GTK_DIALOG_MODAL, GTK_MESSAGE_QUESTION, GTK_BUTTONS_YES_NO,
+				"You are about to close %d tabs. Are you sure you want to continue?", terminal->terms->len);
+		gtk_window_set_title(GTK_WINDOW(dialog), "Confirm close");
+		gint result = gtk_dialog_run(GTK_DIALOG(dialog));
+		gtk_widget_destroy(dialog);
+		if (result == GTK_RESPONSE_YES)
+		{
+			close_flag = 1;
+		}
+	}
+	else
+	{
+		close_flag = 1;
+	}
+	if (close_flag)
+	{
+		return FALSE;
+	}
+	return TRUE;
+}
+
 /* Weak-notify callback for LXTerminal object. */
 static void terminal_window_exit(LXTerminal * terminal, GObject * where_the_object_was)
 {
@@ -836,38 +886,38 @@ static void terminal_child_exited_event(VteTerminal * vte, gint status, Term * t
 static void terminal_child_exited_event(VteTerminal * vte, Term * term)
 #endif
 {
-    LXTerminal * terminal = term->parent;
+	LXTerminal * terminal = term->parent;
 
-    /* Last tab being deleted.  Deallocate memory and close the window. */
-    if (gtk_notebook_get_n_pages(GTK_NOTEBOOK(terminal->notebook)) == 1)
-    {
-        g_ptr_array_free(terminal->terms, TRUE);
-        gtk_widget_destroy(terminal->window);
-    }
+	/* Last tab being deleted.  Deallocate memory and close the window. */
+	if (gtk_notebook_get_n_pages(GTK_NOTEBOOK(terminal->notebook)) == 1)
+	{
+		g_ptr_array_free(terminal->terms, TRUE);
+		gtk_widget_destroy(terminal->window);
+	}
 
-    /* Not last tab being deleted. */
-    else
-    {
-        /* Remove the element and decrease the index number of each succeeding element. */
-        g_ptr_array_remove_index(terminal->terms, term->index);
-        guint i;
-        for (i = term->index; i < terminal->terms->len; i++)
-        {
-            Term * t = g_ptr_array_index(terminal->terms, i);
-            t->index --;
-        }
+	/* Not last tab being deleted. */
+	else
+	{
+		/* Remove the element and decrease the index number of each succeeding element. */
+		g_ptr_array_remove_index(terminal->terms, term->index);
+		guint i;
+		for (i = term->index; i < terminal->terms->len; i++)
+		{
+			Term * t = g_ptr_array_index(terminal->terms, i);
+			t->index --;
+		}
 
-        /* Delete the tab and free the Term structure. */
-        gtk_notebook_remove_page(GTK_NOTEBOOK(terminal->notebook), term->index);
-        terminal_free(term);
+		/* Delete the tab and free the Term structure. */
+		gtk_notebook_remove_page(GTK_NOTEBOOK(terminal->notebook), term->index);
+		terminal_free(term);
 
-        /* If only one page is left, hide the tab. */
-        if (gtk_notebook_get_n_pages(GTK_NOTEBOOK(terminal->notebook)) == 1)
-            gtk_notebook_set_show_tabs(GTK_NOTEBOOK(terminal->notebook), FALSE);
+		/* If only one page is left, hide the tab. */
+		if (gtk_notebook_get_n_pages(GTK_NOTEBOOK(terminal->notebook)) == 1)
+			gtk_notebook_set_show_tabs(GTK_NOTEBOOK(terminal->notebook), FALSE);
 
-        /* update <ALT>n status */
-        terminal_update_alt(terminal);
-    }
+		/* update <ALT>n status */
+		terminal_update_alt(terminal);
+	}
 }
 
 /* Adapter for "activate" signal on Close button of tab and File/Close Tab menu item and accelerator. */
@@ -1499,6 +1549,8 @@ LXTerminal * lxterminal_initialize(LXTermWindow * lxtermwin, CommandArguments * 
         G_CALLBACK(terminal_settings_apply), terminal);
     g_signal_connect(G_OBJECT(terminal->notebook), "switch-page", 
         G_CALLBACK(terminal_switch_page_event), terminal);
+    g_signal_connect(G_OBJECT(terminal->window), "delete-event",
+		G_CALLBACK(terminal_close_window_confirmation_event), terminal);
 
     /* Create the first terminal. */
     gchar * local_working_directory = NULL;


### PR DESCRIPTION
Close: #15 
Add a confirmation dialog to ask user for sure before close a multi-tab lxterminal.
When user close a multi-tab lxterminal, the dialog will appear in three actions:
1. Alt+F4
2. The "X" on the upper-left corner
3. Menu bar: File -> Close_Window
4. Control + Shift + Q
![image](https://cloud.githubusercontent.com/assets/17449636/15803597/6d945460-2b18-11e6-8d88-b77ea5831439.png)
