### PR TITLE
Add an option to disable confirmation before close multi-tab terminal

### DIFF
--- a/data/lxterminal-preferences.glade
+++ b/data/lxterminal-preferences.glade
@@ -969,6 +969,34 @@
                   </packing>
                 </child>
                 <child>
+                  <object class="GtkLabel" id="label_disable_confirm">
+                    <property name="visible">True</property>
+                    <property name="can_focus">False</property>
+                    <property name="xalign">1</property>
+                    <property name="label" translatable="yes">Disable confirmation before close a multi-tab terminal</property>
+                  </object>
+                  <packing>
+                    <property name="top_attach">3</property>
+                    <property name="bottom_attach">4</property>
+                    <property name="y_options">GTK_FILL</property>
+                  </packing>
+                </child>
+                <child>
+                  <object class="GtkCheckButton" id="disable_confirm">
+                    <property name="visible">True</property>
+                    <property name="can_focus">True</property>
+                    <property name="receives_default">False</property>
+                    <property name="draw_indicator">True</property>
+                  </object>
+                  <packing>
+                    <property name="left_attach">1</property>
+                    <property name="right_attach">2</property>
+                    <property name="top_attach">3</property>
+                    <property name="bottom_attach">4</property>
+                    <property name="y_options">GTK_FILL</property>
+                  </packing>
+                </child>
+                <child>
                   <object class="GtkEntry" id="select_by_word">
                     <property name="visible">True</property>
                     <property name="can_focus">True</property>

--- a/po/zh_TW.po
+++ b/po/zh_TW.po
@@ -395,6 +395,10 @@ msgstr "停用選單捷徑鍵 (預設為 F10)"
 msgid "Disable using Alt-n for tabs and menu"
 msgstr "停用以 Alt-n 切換分頁及選單"
 
+#: ../data/lxterminal-preferences.glade.h:39
+msgid "Disable confirmation before close a multi-tab terminal"
+msgstr "停用關閉多個分頁時的確認視窗"
+
 #: ../data/lxterminal-preferences.glade.h:22
 msgid "Advanced"
 msgstr "進階"

--- a/src/lxterminal.c
+++ b/src/lxterminal.c
@@ -451,23 +451,19 @@ static void terminal_close_tab_activate_event(GtkAction * action, LXTerminal * t
  * Close the current window. */
 static void terminal_close_window_activate_event(GtkAction * action, LXTerminal * terminal)
 {
-    int close_flag = 0;
-    if (terminal->terms->len > 1)
+    int close_flag = 1;
+    if (!get_setting()->disable_confirm && terminal->terms->len > 1)
     {
         GtkWidget * dialog = gtk_message_dialog_new(
                 GTK_WIDGET(terminal->window), GTK_DIALOG_MODAL, GTK_MESSAGE_QUESTION, GTK_BUTTONS_YES_NO,
-                "You are about to close %d tabs. Are you sure you want to continue?", terminal->terms->len);
+                _("You are about to close %d tabs. Are you sure you want to continue?"), terminal->terms->len);
         gtk_window_set_title(GTK_WINDOW(dialog), "Confirm close");
         gint result = gtk_dialog_run(GTK_DIALOG(dialog));
         gtk_widget_destroy(dialog);
-        if (result == GTK_RESPONSE_YES)
+        if (result == GTK_RESPONSE_NO)
         {
-            close_flag = 1;
+            close_flag = 0;
         }
-    }
-    else
-    {
-        close_flag = 1;
     }
     if (close_flag)
     {
@@ -831,23 +827,19 @@ static void terminal_window_title_changed_event(GtkWidget * vte, Term * term)
 /* Handler for "delete-event" signal on a LXTerminal. */
 static gboolean terminal_close_window_confirmation_event(GtkWidget * widget, GdkEventButton * event, LXTerminal * terminal)
 {
-    int close_flag = 0;
-    if (terminal->terms->len > 1)
+    int close_flag = 1;
+    if (!get_setting()->disable_confirm && terminal->terms->len > 1)
     {
         GtkWidget * dialog = gtk_message_dialog_new(
                 GTK_WIDGET(terminal->window), GTK_DIALOG_MODAL, GTK_MESSAGE_QUESTION, GTK_BUTTONS_YES_NO,
-                "You are about to close %d tabs. Are you sure you want to continue?", terminal->terms->len);
+                _("You are about to close %d tabs. Are you sure you want to continue?"), terminal->terms->len);
         gtk_window_set_title(GTK_WINDOW(dialog), "Confirm close");
         gint result = gtk_dialog_run(GTK_DIALOG(dialog));
         gtk_widget_destroy(dialog);
-        if (result == GTK_RESPONSE_YES)
+        if (result == GTK_RESPONSE_NO)
         {
-            close_flag = 1;
+            close_flag = 0;
         }
-    }
-    else
-    {
-        close_flag = 1;
     }
     if (close_flag)
     {

--- a/src/lxterminal.h
+++ b/src/lxterminal.h
@@ -29,44 +29,44 @@
 
 /* Top level application context. */
 typedef struct _lxtermwindow {
-//    Setting * setting;				/* Pointer to current user preferences */
-    GPtrArray * windows;			/* Array of pointers to LXTerminal structures */
+//    Setting * setting;                /* Pointer to current user preferences */
+    GPtrArray * windows;            /* Array of pointers to LXTerminal structures */
 } LXTermWindow;
 
 /* Representative of a toplevel window. */
 typedef struct _lxterminal {
-    LXTermWindow * parent;			/* Back pointer to top level context */
-    gint index;					/* Index of this element in parent->windows */
-    GtkWidget * window;				/* Toplevel window */
-    GtkWidget * box;				/* Vertical box, child of toplevel window */
-    GtkWidget * menu;				/* Menu bar, child of vertical box */
+    LXTermWindow * parent;          /* Back pointer to top level context */
+    gint index;                 /* Index of this element in parent->windows */
+    GtkWidget * window;             /* Toplevel window */
+    GtkWidget * box;                /* Vertical box, child of toplevel window */
+    GtkWidget * menu;               /* Menu bar, child of vertical box */
     GtkActionGroup *action_group;   /* Action group on this window */
-    GtkAccelGroup * accel_group;		/* Accelerator group for accelerators on this window */
-    GtkWidget * notebook;			/* Notebook, child of vertical box */
-    GPtrArray * terms;				/* Array of pointers to Term structures */
-//    Setting * setting;				/* A copy of parent->setting */
-    GdkGeometry geometry;			/* Geometry hints (see XGetWMNormalHints) */
-    GdkWindowHints geometry_mask;		/* Mask of valid data in geometry hints */
-    gboolean rgba;				/* True if colormap is RGBA */
-    GdkColor background;			/* User preference background color converted to GdkColor */
-    GdkColor foreground;			/* User preference foreground color converted to GdkColor */
-    gint tab_position;				/* Tab position as an integer value */
-    gboolean login_shell;			/* Terminal will spawn login shells */
+    GtkAccelGroup * accel_group;        /* Accelerator group for accelerators on this window */
+    GtkWidget * notebook;           /* Notebook, child of vertical box */
+    GPtrArray * terms;              /* Array of pointers to Term structures */
+//    Setting * setting;                /* A copy of parent->setting */
+    GdkGeometry geometry;           /* Geometry hints (see XGetWMNormalHints) */
+    GdkWindowHints geometry_mask;       /* Mask of valid data in geometry hints */
+    gboolean rgba;              /* True if colormap is RGBA */
+    GdkColor background;            /* User preference background color converted to GdkColor */
+    GdkColor foreground;            /* User preference foreground color converted to GdkColor */
+    gint tab_position;              /* Tab position as an integer value */
+    gboolean login_shell;           /* Terminal will spawn login shells */
 } LXTerminal;
 
 /* Representative of a tab within a toplevel window. */
 typedef struct _term {
-    LXTerminal * parent;			/* Back pointer to LXTerminal */
-    gint index;					/* Index of this element in parent->terms */
-    GtkWidget * tab;				/* Toplevel of the tab */
-    GtkWidget * label;				/* Label of the tab, child of the toplevel */
-    gboolean user_specified_label;		/* User did "Name Tab", so we will never overwrite this with the window title */
-    GtkWidget * close_button;			/* Close button for the tab, child of the toplevel */
-    GtkWidget * box;				/* Horizontal box, child of notebook */
-    GtkWidget * vte;				/* VteTerminal, child of horizontal box */
-    GtkWidget * scrollbar;			/* Scroll bar, child of horizontal box */
+    LXTerminal * parent;            /* Back pointer to LXTerminal */
+    gint index;                 /* Index of this element in parent->terms */
+    GtkWidget * tab;                /* Toplevel of the tab */
+    GtkWidget * label;              /* Label of the tab, child of the toplevel */
+    gboolean user_specified_label;      /* User did "Name Tab", so we will never overwrite this with the window title */
+    GtkWidget * close_button;           /* Close button for the tab, child of the toplevel */
+    GtkWidget * box;                /* Horizontal box, child of notebook */
+    GtkWidget * vte;                /* VteTerminal, child of horizontal box */
+    GtkWidget * scrollbar;          /* Scroll bar, child of horizontal box */
     GPid pid;                                   /* Process ID of the process that has this as its terminal */
-    GClosure * closure;				/* Accelerator structure */
+    GClosure * closure;             /* Accelerator structure */
     gchar * matched_url;
     gboolean open_menu_on_button_release;
 #if !VTE_CHECK_VERSION (0, 38, 0)
@@ -76,14 +76,14 @@ typedef struct _term {
 
 /* Output of lxterminal_process_arguments. */
 typedef struct _command_arguments {
-    char * executable;				/* Value of argv[0]; points into argument vector */
-    gchar * * command;				/* Value of -e, --command; memory allocated by glib */
-    int geometry_columns;			/* Value of --geometry */
+    char * executable;              /* Value of argv[0]; points into argument vector */
+    gchar * * command;              /* Value of -e, --command; memory allocated by glib */
+    int geometry_columns;           /* Value of --geometry */
     int geometry_rows;
-    char * title; 				/* Value of -t, -T, --title; points into argument vector */
-    char * tabs; 				/* Value of --tab; points into argument vector */
-    char * working_directory;			/* Value of --working-directory; points into argument vector */
-    gboolean login_shell;			/* Terminal will spawn login shells */
+    char * title;               /* Value of -t, -T, --title; points into argument vector */
+    char * tabs;                /* Value of --tab; points into argument vector */
+    char * working_directory;           /* Value of --working-directory; points into argument vector */
+    gboolean login_shell;           /* Terminal will spawn login shells */
     gboolean no_remote;
 } CommandArguments;
 

--- a/src/preferences.c
+++ b/src/preferences.c
@@ -416,7 +416,12 @@ void terminal_preferences_dialog(GtkAction * action, LXTerminal * terminal)
     g_signal_connect(G_OBJECT(w), "toggled", 
         G_CALLBACK(preferences_dialog_generic_toggled_event), &setting->disable_alt);
     
-    /* Shortcuts */
+    w = GTK_WIDGET(gtk_builder_get_object(builder, "disable_confirm"));
+    gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(w), setting->disable_confirm);
+    g_signal_connect(G_OBJECT(w), "toggled", 
+        G_CALLBACK(preferences_dialog_generic_toggled_event), &setting->disable_confirm);
+    
+	/* Shortcuts */
     w = GTK_WIDGET(gtk_builder_get_object(builder, NEW_WINDOW_ACCEL));
     gtk_entry_set_text(GTK_ENTRY(w), setting->new_window_accel);
     g_signal_connect(G_OBJECT(w), "focus-out-event", 

--- a/src/setting.c
+++ b/src/setting.c
@@ -120,6 +120,7 @@ void print_setting()
     printf("Word selection characters: %s\n", setting->word_selection_characters);
     printf("Disable F10: %i\n", setting->disable_f10);
     printf("Disable Alt: %i\n", setting->disable_alt);
+    printf("Disable Confirm: %i\n", setting->disable_confirm);
     printf("Geometry change: %i\n", setting->geometry_change);
     
     /* Shortcut group settings. */
@@ -206,6 +207,7 @@ void save_setting()
     g_key_file_set_string(setting->keyfile, GENERAL_GROUP, SEL_CHARS, setting->word_selection_characters);
     g_key_file_set_boolean(setting->keyfile, GENERAL_GROUP, DISABLE_F10, setting->disable_f10);
     g_key_file_set_boolean(setting->keyfile, GENERAL_GROUP, DISABLE_ALT, setting->disable_alt);
+    g_key_file_set_boolean(setting->keyfile, GENERAL_GROUP, DISABLE_CONFIRM, setting->disable_confirm);
 
     /* Shortcut group settings. */
     g_key_file_set_string(setting->keyfile, SHORTCUT_GROUP, NEW_WINDOW_ACCEL, setting->new_window_accel);
@@ -422,6 +424,7 @@ color_preset_does_not_exist:
         setting->word_selection_characters = g_key_file_get_string(setting->keyfile, GENERAL_GROUP, SEL_CHARS, NULL);
         setting->disable_f10 = g_key_file_get_boolean(setting->keyfile, GENERAL_GROUP, DISABLE_F10, NULL);
         setting->disable_alt = g_key_file_get_boolean(setting->keyfile, GENERAL_GROUP, DISABLE_ALT, NULL);
+        setting->disable_confirm = g_key_file_get_boolean(setting->keyfile, GENERAL_GROUP, DISABLE_CONFIRM, NULL);
         
         /* Shortcut group settings. */
         setting->new_window_accel = g_key_file_get_string(setting->keyfile, SHORTCUT_GROUP, NEW_WINDOW_ACCEL, NULL);

--- a/src/setting.h
+++ b/src/setting.h
@@ -44,6 +44,7 @@
 #define SEL_CHARS "selchars"
 #define DISABLE_F10 "disablef10"
 #define DISABLE_ALT "disablealt"
+#define DISABLE_CONFIRM "disableconfirm"
 #define PALETTE_COLOR_PREFIX "palette_color_"
 #define COLOR_PRESET "color_preset"
 
@@ -109,6 +110,7 @@ typedef struct _setting {
     char * word_selection_characters;   /* Characters that act as word breaks during selection by word */
     gboolean disable_f10;       /* True if F10 will be passed to program; false if it brings up File menu */
     gboolean disable_alt;       /* True if Alt-n is passed to shell; false if it is used to switch between tabs */
+    gboolean disable_confirm;   /* True if confirmation exit dialog shows before terminal window close*/
 
     gboolean geometry_change;       /* True if there is a geometry change, until it has been acted on */
     


### PR DESCRIPTION
Ref: https://github.com/lxde/lxterminal/pull/17#issuecomment-223953698
@medicalwei 
I add an option to disable the confirm dialog when a multi-tab lxterminal is closed,
in the Advanced tab of Preferences.
![image](https://cloud.githubusercontent.com/assets/17449636/15833113/cd763124-2c57-11e6-8c9f-1a353d47d9e7.png)

And I have a question about zh_TW.po:398,
what number should I fill in "#: ../data/lxterminal-preferences.glade.h:XX"
I just fill the last and not in used number.