### PR TITLE
properly null-terminate arguments after copy

### DIFF
--- a/src/lxterminal.c
+++ b/src/lxterminal.c
@@ -1434,11 +1434,12 @@ gboolean lxterminal_process_arguments(gint argc, gchar * * argv, CommandArgument
         }
         else
         {
-            gchar * * tmp = g_malloc((cmd_len + 3) * sizeof(gchar *));
+            gchar * * tmp = g_malloc((cmd_len + 4) * sizeof(gchar *));
             tmp[0] = g_strdup(shell);
             tmp[1] = g_strdup_printf("-%s", shellname);
             tmp[2] = g_strdup("-c");
             memcpy((tmp + 3), arguments->command, cmd_len * sizeof(gchar *));
+            tmp[cmd_len + 3] = NULL;
             g_free(arguments->command);
             arguments->command = tmp;
         }
@@ -1448,9 +1449,10 @@ gboolean lxterminal_process_arguments(gint argc, gchar * * argv, CommandArgument
     {
         if(arguments->command != NULL)
         {
-            gchar * * tmp = g_malloc((cmd_len + 1) * sizeof(gchar *));
+            gchar * * tmp = g_malloc((cmd_len + 2) * sizeof(gchar *));
             tmp[0] = g_strdup(arguments->command[0]);
             memcpy((tmp + 1), arguments->command, cmd_len * sizeof(gchar *));
+            tmp[cmd_len + 1] = NULL;
             g_free(arguments->command);
             arguments->command = tmp;
         }


### PR DESCRIPTION
ref: https://sourceforge.net/p/lxde/bugs/827/

Actually "lxterminal --command=ls" for example causes segfault like:
```
Program received signal SIGSEGV, Segmentation fault.
__GI___libc_free (mem=0x747542207265776f) at malloc.c:2949
2949      if (chunk_is_mmapped (p))                       /* release mmapped memory. */
(gdb) bt
#0  0x00007ffff4b88282 in __GI___libc_free (mem=0x747542207265776f) at malloc.c:2949
#1  0x00007ffff7b19f6e in g_free (mem=0x747542207265776f) at gmem.c:189
#2  0x00007ffff7b34289 in g_strfreev (str_array=0x5555557a8510) at gstrfuncs.c:2487
#3  0x000055555555f666 in terminal_new (terminal=0x5555557af020, label=<optimized out>, pwd=0x5555558a80e0 "/home/mtasaka", exec=0x5555557a8510, env=0x0)
    at lxterminal.c:1242
#4  0x000055555556070d in lxterminal_initialize (lxtermwin=<optimized out>, arguments=0x7fffffffddd0) at lxterminal.c:1539
#5  0x000055555555b8f2 in main (argc=<optimized out>, argv=<optimized out>) at lxterminal.c:1724
(gdb) up
#1  0x00007ffff7b19f6e in g_free (mem=0x747542207265776f) at gmem.c:189
189         free (mem);
(gdb) up
#2  0x00007ffff7b34289 in g_strfreev (str_array=0x5555557a8510) at gstrfuncs.c:2487
2487            g_free (str_array[i]);
(gdb) up
#3  0x000055555555f666 in terminal_new (terminal=0x5555557af020, label=<optimized out>, pwd=0x5555558a80e0 "/home/mtasaka", exec=0x5555557a8510, env=0x0)
    at lxterminal.c:1242
1242        g_strfreev(exec);
(gdb) p exec[2]
$3 = (gchar *) 0x747542207265776f <error: Cannot access memory at address 0x747542207265776f>
```

So exec[2] points to some garbage pointer.

With g_shell_parse_argv(), the returned *argcp value does not count the last "NULL" element. So when copying *argvp array with *argcp element, the final element must be set to NULL manually.