### PR TITLE
Updated building instruction (Ubuntu)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# LXterminal
+# LXTerminal
 
-LXterminal is a VTE-based terminal emulator with support for multiple tabs. 
+LXTerminal is a VTE-based terminal emulator with support for multiple tabs. 
 It is completely desktop-independent and does not have any unnecessary 
 dependencies. In order to reduce memory usage and increase the performance 
 all instances of the terminal are sharing a single process.
@@ -9,15 +9,17 @@ all instances of the terminal are sharing a single process.
 - Single instance setting for all windows
 - Load menubar from menu.ui
 - Extract shortcut from ui_manager after loading GtkActionEntry
-- Smart copy - may set <CTRL>C for copy - test selected symbol, if selected - copy, otherwise send key to terminal
+- Smart copy - may set CTRL+C for copy - test selected symbol, if selected - copy, otherwise send key to terminal
 - Update .po for Shortcut Prefernces tab, update ru.po localization.
 
 ##  Install
 
-See INSTALL, and if you want to build LXterminal on ubuntu, you may try
+See INSTALL, and if you want to build LXTerminal, you may try next:
+
+### Ubuntu
 
 ```
-apt-get install autoconf xsltproc docbook-xml docbook-xsl  git
+apt-get install autoconf docbook-xml docbook-xsl git intltool libgtk2.0-dev libvte-dev xsltproc
 git clone https://github.com/lxde/lxterminal.git
 cd lxterminal
 apt-get build-dep lxterminal


### PR DESCRIPTION
Added more required packages.
"apt-get build-dep lxterminal" may not be executed, because it shows the mistake "E: You must put some 'source' URIs in your source.list". I don't know what is it, so I didn't remove it just in case.
This instruction was tested on Lubuntu 16.04.1 LTS x64.