### PR TITLE
Added remembering of window size (need help)

### DIFF
--- a/src/lxterminal.c
+++ b/src/lxterminal.c
@@ -1547,6 +1547,9 @@ LXTerminal * lxterminal_initialize(LXTermWindow * lxtermwin, CommandArguments * 
     /* Set window title. */
     gtk_window_set_title(GTK_WINDOW(terminal->window), gtk_label_get_text(GTK_LABEL(term->label)));
 
+    /* Set window width and height. */
+    gtk_window_set_default_size(GTK_WINDOW(terminal->window), &setting->width, &setting->height);
+
     /* Set the terminal geometry. */
     if ((arguments->geometry_columns != 0) && (arguments->geometry_rows != 0)) {
         vte_terminal_set_size(VTE_TERMINAL(term->vte), arguments->geometry_columns, arguments->geometry_rows);

--- a/src/setting.c
+++ b/src/setting.c
@@ -91,6 +91,8 @@ void print_setting()
 {
     g_return_if_fail (setting != NULL);
 
+    printf("Window width: %i\n", setting->width);
+    printf("Window height: %i\n", setting->height);
     printf("Font name: %s\n", setting->font_name);
 #if VTE_CHECK_VERSION (0, 38, 0)
     gchar * p = gdk_rgba_to_string(&setting->background_color);
@@ -160,6 +162,9 @@ void save_setting()
     //print_setting();
     
     /* Push settings to GKeyFile. */
+    gtk_window_get_size(GTK_WINDOW(terminal->window), &setting->width, &setting->height);
+    g_key_file_set_integer(setting->keyfile, GENERAL_GROUP, WIDTH, setting->width);
+    g_key_file_set_integer(setting->keyfile, GENERAL_GROUP, HEIGHT, setting->height);
     g_key_file_set_string(setting->keyfile, GENERAL_GROUP, FONT_NAME, setting->font_name);
 #if VTE_CHECK_VERSION (0, 38, 0)
     gchar * p = gdk_rgba_to_string(&setting->background_color);
@@ -259,6 +264,8 @@ Setting * copy_setting(Setting * setting)
     Setting * new_setting = g_slice_new0(Setting);
     memcpy(new_setting, setting, sizeof(Setting));
 
+    new_setting->width = g_strdup(setting->width);
+    new_setting->height = g_strdup(setting->height);
     new_setting->font_name = g_strdup(setting->font_name);
     new_setting->tab_position = g_strdup(setting->tab_position);
     new_setting->word_selection_characters = g_strdup(setting->word_selection_characters);
@@ -344,6 +351,8 @@ Setting * load_setting()
     if ((g_file_test(config_path, G_FILE_TEST_EXISTS))
     && (g_key_file_load_from_file(setting->keyfile, config_path, G_KEY_FILE_KEEP_COMMENTS | G_KEY_FILE_KEEP_TRANSLATIONS, &error)))
     {
+        setting->width = g_key_file_get_integer(setting->keyfile, GENERAL_GROUP, WIDTH, &error);
+        setting->height = g_key_file_get_integer(setting->keyfile, GENERAL_GROUP, HEIGHT, &error);
         setting->font_name = g_key_file_get_string(setting->keyfile, GENERAL_GROUP, FONT_NAME, NULL);
         char * p = g_key_file_get_string(setting->keyfile, GENERAL_GROUP, BG_COLOR, NULL);
         if (p != NULL)

--- a/src/setting.h
+++ b/src/setting.h
@@ -25,6 +25,8 @@
 #include <vte/vte.h>
 
 #define GENERAL_GROUP "general"
+#define WIDTH "width"
+#define HEIGHT "height"
 #define FONT_NAME "fontname"
 #define FG_COLOR "fgcolor"
 #define BG_COLOR "bgcolor"
@@ -83,6 +85,8 @@
 typedef struct _setting {
 
     GKeyFile * keyfile;         /* Pointer to GKeyFile containing settings */
+    gint width;                 /* Window width */
+    gint height;                /* Window height */
     char * font_name;           /* Font name */
 #if VTE_CHECK_VERSION (0, 38, 0)
     GdkRGBA background_color;      /* Background color */


### PR DESCRIPTION
Hello LXTerminal developers!
I want to make pull-request for remembering of window size for LXTerminal, but I need help. When compiling I get this one:

> sauron@mordor:~/lxterminal$ make
make  all-recursive
make[1]: entering directory «/home/maxpayne/lxterminal»
Making all in src
make[2]: entering directory «/home/maxpayne/lxterminal/src»
  CC       lxterminal-setting.o
In file included from /usr/include/glib-2.0/gobject/gobject.h:24:0,
                 from /usr/include/glib-2.0/gobject/gbinding.h:29,
                 from /usr/include/glib-2.0/glib-object.h:23,
                 from /usr/include/glib-2.0/gio/gioenums.h:28,
                 from /usr/include/glib-2.0/gio/giotypes.h:28,
                 from /usr/include/glib-2.0/gio/gio.h:26,
                 from /usr/include/gtk-2.0/gdk/gdkapplaunchcontext.h:30,
                 from /usr/include/gtk-2.0/gdk/gdk.h:32,
                 from /usr/include/gtk-2.0/gtk/gtk.h:32,
                 from setting.c:22:
setting.c: In function ‘save_setting’:
setting.c:169:36: error: ‘terminal’ undeclared (first use in this function)
     gtk_window_get_size(GTK_WINDOW(terminal->window), &setting->width, &setting->height);
                                    ^
/usr/include/glib-2.0/gobject/gtype.h:2207:57: note: in definition of macro ‘_G_TYPE_CIC’
     ((ct*) g_type_check_instance_cast ((GTypeInstance*) ip, gt))
                                                         ^
/usr/include/gtk-2.0/gtk/gtkwindow.h:42:28: note: in expansion of macro ‘G_TYPE_CHECK_INSTANCE_CAST’
 #define GTK_WINDOW(obj)   (G_TYPE_CHECK_INSTANCE_CAST ((obj), GTK_TYPE_WINDOW, GtkWindow))
                            ^
setting.c:169:25: note: in expansion of macro ‘GTK_WINDOW’
     gtk_window_get_size(GTK_WINDOW(terminal->window), &setting->width, &setting->height);
                         ^
setting.c:169:36: note: each undeclared identifier is reported only once for each function it appears in
     gtk_window_get_size(GTK_WINDOW(terminal->window), &setting->width, &setting->height);
                                    ^
/usr/include/glib-2.0/gobject/gtype.h:2207:57: note: in definition of macro ‘_G_TYPE_CIC’
     ((ct*) g_type_check_instance_cast ((GTypeInstance*) ip, gt))
                                                         ^
/usr/include/gtk-2.0/gtk/gtkwindow.h:42:28: note: in expansion of macro ‘G_TYPE_CHECK_INSTANCE_CAST’
 #define GTK_WINDOW(obj)   (G_TYPE_CHECK_INSTANCE_CAST ((obj), GTK_TYPE_WINDOW, GtkWindow))
                            ^
setting.c:169:25: note: in expansion of macro ‘GTK_WINDOW’
     gtk_window_get_size(GTK_WINDOW(terminal->window), &setting->width, &setting->height);
                         ^
Makefile:447: recipe for target «lxterminal-setting.o» failed
make[2]: *** [lxterminal-setting.o] Error 1
make[2]: leaving directory «/home/maxpayne/lxterminal/src»
Makefile:400: recipe for target «all-recursive» failed
make[1]: *** [all-recursive] Error 1
make[1]: leaving directory «/home/maxpayne/lxterminal»
Makefile:341: recipe for target «all» failed
make: *** [all] Error 2

I am not programmer at all, so please, help me to fix it.