### PR TITLE
Allow tab width to be set via "Edit -> Preferences -> Advanced".

### DIFF
--- a/data/lxterminal-preferences.glade
+++ b/data/lxterminal-preferences.glade
@@ -20,6 +20,12 @@
     <property name="step_increment">10</property>
     <property name="page_increment">10</property>
   </object>
+  <object class="GtkAdjustment" id="tab_width_adjustment">
+    <property name="upper">1000</property>
+    <property name="value">100</property>
+    <property name="step_increment">1</property>
+    <property name="page_increment">10</property>
+  </object>
   <object class="GtkListStore" id="values_color_presets">
     <columns>
       <!-- column-name gchararray1 -->
@@ -997,6 +1003,19 @@
                   </packing>
                 </child>
                 <child>
+                  <object class="GtkLabel" id="label_tab_width">
+                    <property name="visible">True</property>
+                    <property name="can_focus">False</property>
+                    <property name="xalign">1</property>
+                    <property name="label" translatable="yes">Tab width</property>
+                  </object>
+                  <packing>
+                    <property name="top_attach">4</property>
+                    <property name="bottom_attach">5</property>
+                    <property name="y_options">GTK_FILL</property>
+                  </packing>
+                </child>
+                <child>
                   <object class="GtkEntry" id="select_by_word">
                     <property name="visible">True</property>
                     <property name="can_focus">True</property>
@@ -1009,6 +1028,26 @@
                   <packing>
                     <property name="left_attach">1</property>
                     <property name="right_attach">2</property>
+                    <property name="y_options">GTK_FILL</property>
+                  </packing>
+                </child>
+                <child>
+                  <object class="GtkSpinButton" id="tab_width">
+                    <property name="visible">True</property>
+                    <property name="can_focus">True</property>
+                    <property name="invisible_char">•</property>
+                    <property name="width_chars">4</property>
+                    <property name="primary_icon_activatable">False</property>
+                    <property name="secondary_icon_activatable">False</property>
+                    <property name="primary_icon_sensitive">True</property>
+                    <property name="secondary_icon_sensitive">True</property>
+                    <property name="adjustment">tab_width_adjustment</property>
+                  </object>
+                  <packing>
+                    <property name="left_attach">1</property>
+                    <property name="right_attach">2</property>
+                    <property name="top_attach">4</property>
+                    <property name="bottom_attach">5</property>
                     <property name="y_options">GTK_FILL</property>
                   </packing>
                 </child>

--- a/po/he.po
+++ b/po/he.po
@@ -8,7 +8,7 @@ msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2017-01-24 12:14+0800\n"
-"PO-Revision-Date: 2017-05-23 06:57+0000\n"
+"PO-Revision-Date: 2017-11-14 12:03+0000\n"
 "Last-Translator: Yaron Shahrabani <sh.yaron@gmail.com>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
 "Language: he\n"
@@ -17,7 +17,7 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 "X-Generator: Pootle 2.8\n"
-"X-POOTLE-MTIME: 1495522671.796582\n"
+"X-POOTLE-MTIME: 1510661022.718900\n"
 
 #. 0
 #: ../src/lxterminal.c:121
@@ -178,7 +178,7 @@ msgstr "תכנית להדמיית מסוף עבור מיזם LXDE"
 #: ../src/lxterminal.c:814
 #, c-format
 msgid "You are about to close %d tabs. Are you sure you want to continue?"
-msgstr ""
+msgstr "%d לשוניות מועמדות לסגירה. להמשיך?"
 
 #: ../src/lxterminal.c:815
 msgid "Confirm close"
@@ -266,11 +266,11 @@ msgstr "כחול"
 
 #: ../data/lxterminal-preferences.glade.h:20
 msgid "Magenta"
-msgstr ""
+msgstr "ארגמן"
 
 #: ../data/lxterminal-preferences.glade.h:21
 msgid "Cyan"
-msgstr ""
+msgstr "ציאן"
 
 #: ../data/lxterminal-preferences.glade.h:22
 msgid "Gray"
@@ -294,15 +294,15 @@ msgstr "צהוב"
 
 #: ../data/lxterminal-preferences.glade.h:27
 msgid "Bright Blue"
-msgstr ""
+msgstr "כחול בהיר"
 
 #: ../data/lxterminal-preferences.glade.h:28
 msgid "Bright Magenta"
-msgstr ""
+msgstr "ארגמן בהיר"
 
 #: ../data/lxterminal-preferences.glade.h:29
 msgid "Bright Cyan"
-msgstr ""
+msgstr "ציאן בהיר"
 
 #: ../data/lxterminal-preferences.glade.h:30
 msgid "White"
@@ -370,7 +370,7 @@ msgstr "ביטול השימוש ב־Alt-מספר עבור הלשוניות וה�
 
 #: ../data/lxterminal-preferences.glade.h:46
 msgid "Disable confirmation before closing a window with multiple tabs"
-msgstr ""
+msgstr "ביטול האישור בטרם סגירת חלון עם מגוון לשוניות"
 
 #: ../data/lxterminal-preferences.glade.h:47
 msgid "Advanced"

--- a/src/lxterminal.c
+++ b/src/lxterminal.c
@@ -430,6 +430,7 @@ static void terminal_new_tab(LXTerminal * terminal, const gchar * label)
 
     /* Add a tab to the notebook and the "terms" array. */
     gtk_notebook_append_page(GTK_NOTEBOOK(terminal->notebook), term->box, term->tab);
+    gtk_notebook_set_tab_reorderable(GTK_NOTEBOOK(terminal->notebook), term->box, TRUE);
     term->index = gtk_notebook_get_n_pages(GTK_NOTEBOOK(terminal->notebook)) - 1;
     g_ptr_array_add(terminal->terms, term);
 
@@ -1591,6 +1592,7 @@ LXTerminal * lxterminal_initialize(LXTermWindow * lxtermwin, CommandArguments * 
 
     /* Add the first terminal to the notebook and the data structures. */
     gtk_notebook_append_page(GTK_NOTEBOOK(terminal->notebook), term->box, term->tab);
+    gtk_notebook_set_tab_reorderable(GTK_NOTEBOOK(terminal->notebook), term->box, TRUE);
     term->index = gtk_notebook_get_n_pages(GTK_NOTEBOOK(terminal->notebook)) - 1;
     g_ptr_array_add(terminal->terms, term);
 

--- a/src/lxterminal.c
+++ b/src/lxterminal.c
@@ -432,7 +432,6 @@ static void terminal_new_tab(LXTerminal * terminal, const gchar * label)
 
     /* Add a tab to the notebook and the "terms" array. */
     gtk_notebook_append_page(GTK_NOTEBOOK(terminal->notebook), term->box, term->tab);
-    gtk_notebook_set_tab_reorderable(GTK_NOTEBOOK(terminal->notebook), term->box, TRUE);
     term->index = gtk_notebook_get_n_pages(GTK_NOTEBOOK(terminal->notebook)) - 1;
     g_ptr_array_add(terminal->terms, term);
 
@@ -1624,7 +1623,6 @@ LXTerminal * lxterminal_initialize(LXTermWindow * lxtermwin, CommandArguments * 
 
     /* Add the first terminal to the notebook and the data structures. */
     gtk_notebook_append_page(GTK_NOTEBOOK(terminal->notebook), term->box, term->tab);
-    gtk_notebook_set_tab_reorderable(GTK_NOTEBOOK(terminal->notebook), term->box, TRUE);
     term->index = gtk_notebook_get_n_pages(GTK_NOTEBOOK(terminal->notebook)) - 1;
     g_ptr_array_add(terminal->terms, term);
 

--- a/src/lxterminal.c
+++ b/src/lxterminal.c
@@ -1129,6 +1129,8 @@ static void terminal_settings_apply_to_term(LXTerminal * terminal, Term * term)
 /* Create a new terminal. */
 static Term * terminal_new(LXTerminal * terminal, const gchar * label, const gchar * pwd, gchar * * env,  gchar * * exec)
 {
+    Setting * setting = get_setting();
+
     /* Create and initialize Term structure for new terminal. */
     Term * term = g_slice_new0(Term);
     term->parent = terminal;
@@ -1209,7 +1211,7 @@ static Term * terminal_new(LXTerminal * terminal, const gchar * label, const gch
         term->user_specified_label = FALSE;
     }
     term->label = gtk_label_new((label != NULL) ? label : vte_terminal_get_window_title(VTE_TERMINAL(term->vte)));
-    gtk_widget_set_size_request(GTK_WIDGET(term->label), 100, -1);
+    gtk_widget_set_size_request(GTK_WIDGET(term->label), setting->tab_width, -1);
     gtk_label_set_ellipsize(GTK_LABEL(term->label), PANGO_ELLIPSIZE_END);
     gtk_misc_set_alignment(GTK_MISC(term->label), 0.0, 0.5);
     gtk_misc_set_padding(GTK_MISC(term->label), 0, 0);

--- a/src/preferences.c
+++ b/src/preferences.c
@@ -431,6 +431,11 @@ void terminal_preferences_dialog(GtkAction * action, LXTerminal * terminal)
     g_signal_connect(G_OBJECT(w), "toggled", 
         G_CALLBACK(preferences_dialog_generic_toggled_event), &setting->disable_confirm);
 
+    w = GTK_WIDGET(gtk_builder_get_object(builder, "tab_width"));
+    gtk_spin_button_set_value(GTK_SPIN_BUTTON(w), setting->tab_width);
+    g_signal_connect(G_OBJECT(w), "value-changed", 
+        G_CALLBACK(preferences_dialog_int_value_changed_event), &setting->tab_width);
+
     /* Shortcuts */
 #define PREF_SETUP_SHORTCUT(OBJ, VAR) \
     w = GTK_WIDGET(gtk_builder_get_object(builder, OBJ)); \

--- a/src/setting.c
+++ b/src/setting.c
@@ -132,6 +132,7 @@ void print_setting()
     printf("Disable F10: %i\n", setting->disable_f10);
     printf("Disable Alt: %i\n", setting->disable_alt);
     printf("Disable Confirm: %i\n", setting->disable_confirm);
+    printf("Tab width: %i\n", setting->tab_width);
     printf("Geometry change: %i\n", setting->geometry_change);
     
     /* Shortcut group settings. */
@@ -147,7 +148,7 @@ void print_setting()
     printf("MOVE_TAB_LEFT_ACCEL: %s\n", setting->move_tab_left_accel);
     printf("MOVE_TAB_RIGHT_ACCEL: %s\n", setting->move_tab_right_accel);
 }
-#endif
+#endif /* 0 */
 
 Setting * get_setting()
 {
@@ -219,6 +220,7 @@ void save_setting()
     g_key_file_set_boolean(setting->keyfile, GENERAL_GROUP, DISABLE_F10, setting->disable_f10);
     g_key_file_set_boolean(setting->keyfile, GENERAL_GROUP, DISABLE_ALT, setting->disable_alt);
     g_key_file_set_boolean(setting->keyfile, GENERAL_GROUP, DISABLE_CONFIRM, setting->disable_confirm);
+    g_key_file_set_integer(setting->keyfile, GENERAL_GROUP, TAB_WIDTH, setting->tab_width);
 
     /* Shortcut group settings. */
     g_key_file_set_string(setting->keyfile, SHORTCUT_GROUP, NEW_WINDOW_ACCEL, setting->new_window_accel);
@@ -438,6 +440,11 @@ color_preset_does_not_exist:
         setting->disable_f10 = g_key_file_get_boolean(setting->keyfile, GENERAL_GROUP, DISABLE_F10, NULL);
         setting->disable_alt = g_key_file_get_boolean(setting->keyfile, GENERAL_GROUP, DISABLE_ALT, NULL);
         setting->disable_confirm = g_key_file_get_boolean(setting->keyfile, GENERAL_GROUP, DISABLE_CONFIRM, NULL);
+        g_clear_error(&error);
+        setting->tab_width = g_key_file_get_integer(setting->keyfile, GENERAL_GROUP, TAB_WIDTH, &error);
+        if (error && (error->code == G_KEY_FILE_ERROR_KEY_NOT_FOUND)) {
+            setting->tab_width = 100;
+        }
         
         /* Shortcut group settings. */
         setting->new_window_accel = g_key_file_get_string(setting->keyfile, SHORTCUT_GROUP, NEW_WINDOW_ACCEL, NULL);

--- a/src/setting.h
+++ b/src/setting.h
@@ -45,6 +45,7 @@
 #define DISABLE_F10 "disablef10"
 #define DISABLE_ALT "disablealt"
 #define DISABLE_CONFIRM "disableconfirm"
+#define TAB_WIDTH "tabwidth"
 #define PALETTE_COLOR_PREFIX "palette_color_"
 #define COLOR_PRESET "color_preset"
 
@@ -111,6 +112,7 @@ typedef struct _setting {
     gboolean disable_f10;       /* True if F10 will be passed to program; false if it brings up File menu */
     gboolean disable_alt;       /* True if Alt-n is passed to shell; false if it is used to switch between tabs */
     gboolean disable_confirm;   /* True if confirmation exit dialog shows before terminal window close*/
+    gint tab_width;             /* Tab width */
 
     gboolean geometry_change;       /* True if there is a geometry change, until it has been acted on */
     


### PR DESCRIPTION
The goal of this modification is to allow users, who may open many tabs per window, to see the activity of their tabs without having to hit the left- and right-arrows on the tab line to find out if any of their tabs have had activity.

The new tab width takes effect when the next tab is created.  If a tab width has not yet been set, the width is set to 100 (the default width in previous releases).

It might make for a cleaner UI if, when the new tab width is set, the current child tab label widgets were iterated-through to change their widths to the new setting; I'm open to suggestions as to how to best make that happen.

The proposed max (1000) may be a little high, but I was thinking about the width of screens these days.  (Not sure who would want a tab 1000 pixels wide, though.)

Another option could have the width of each tab auto-resize to fit the contents of its current label, but doing so might defeat the goal of seeing the status of all tabs at once.  (A possible enhancement could be a way to bring up a list of all of the tab titles to see their statuses, like "\<Ctrl-A\> \<Enter\>" in GNU Screen.  Another day, perhaps.)

Any and all comments are welcome.