### PR TITLE
Add support for "bold is bright" setting

### DIFF
--- a/data/lxterminal-preferences.glade
+++ b/data/lxterminal-preferences.glade
@@ -106,7 +106,7 @@
               <object class="GtkTable" id="table_style">
                 <property name="visible">True</property>
                 <property name="can_focus">False</property>
-                <property name="n_rows">10</property>
+                <property name="n_rows">11</property>
                 <property name="n_columns">2</property>
                 <property name="column_spacing">5</property>
                 <property name="row_spacing">3</property>
@@ -219,11 +219,11 @@
                   </packing>
                 </child>
                 <child>
-                  <object class="GtkLabel" id="label_cursor_blink">
+                  <object class="GtkLabel" id="label_bold_bright">
                     <property name="visible">True</property>
                     <property name="can_focus">False</property>
                     <property name="xalign">1</property>
-                    <property name="label" translatable="yes">Cursor blink</property>
+                    <property name="label" translatable="yes">Bold is bright</property>
                   </object>
                   <packing>
                     <property name="top_attach">6</property>
@@ -232,7 +232,7 @@
                   </packing>
                 </child>
                 <child>
-                  <object class="GtkCheckButton" id="cursor_blink">
+                  <object class="GtkCheckButton" id="bold_bright">
                     <property name="visible">True</property>
                     <property name="can_focus">True</property>
                     <property name="receives_default">False</property>
@@ -247,6 +247,34 @@
                   </packing>
                 </child>
                 <child>
+                  <object class="GtkLabel" id="label_cursor_blink">
+                    <property name="visible">True</property>
+                    <property name="can_focus">False</property>
+                    <property name="xalign">1</property>
+                    <property name="label" translatable="yes">Cursor blink</property>
+                  </object>
+                  <packing>
+                    <property name="top_attach">7</property>
+                    <property name="bottom_attach">8</property>
+                    <property name="y_options">GTK_FILL</property>
+                  </packing>
+                </child>
+                <child>
+                  <object class="GtkCheckButton" id="cursor_blink">
+                    <property name="visible">True</property>
+                    <property name="can_focus">True</property>
+                    <property name="receives_default">False</property>
+                    <property name="draw_indicator">True</property>
+                  </object>
+                  <packing>
+                    <property name="left_attach">1</property>
+                    <property name="right_attach">2</property>
+                    <property name="top_attach">7</property>
+                    <property name="bottom_attach">8</property>
+                    <property name="y_options">GTK_FILL</property>
+                  </packing>
+                </child>
+                <child>
                   <object class="GtkLabel" id="label_cursor_style">
                     <property name="visible">True</property>
                     <property name="can_focus">False</property>
@@ -254,8 +282,8 @@
                     <property name="label" translatable="yes">Cursor style</property>
                   </object>
                   <packing>
-                    <property name="top_attach">7</property>
-                    <property name="bottom_attach">9</property>
+                    <property name="top_attach">8</property>
+                    <property name="bottom_attach">10</property>
                     <property name="y_options">GTK_FILL</property>
                   </packing>
                 </child>
@@ -272,8 +300,8 @@
                   <packing>
                     <property name="left_attach">1</property>
                     <property name="right_attach">2</property>
-                    <property name="top_attach">7</property>
-                    <property name="bottom_attach">8</property>
+                    <property name="top_attach">8</property>
+                    <property name="bottom_attach">9</property>
                     <property name="y_options">GTK_FILL</property>
                   </packing>
                 </child>
@@ -291,8 +319,8 @@
                   <packing>
                     <property name="left_attach">1</property>
                     <property name="right_attach">2</property>
-                    <property name="top_attach">8</property>
-                    <property name="bottom_attach">9</property>
+                    <property name="top_attach">9</property>
+                    <property name="bottom_attach">10</property>
                     <property name="y_options">GTK_FILL</property>
                   </packing>
                 </child>
@@ -304,8 +332,8 @@
                     <property name="label" translatable="yes">Audible bell</property>
                   </object>
                   <packing>
-                    <property name="top_attach">9</property>
-                    <property name="bottom_attach">10</property>
+                    <property name="top_attach">10</property>
+                    <property name="bottom_attach">11</property>
                     <property name="y_options">GTK_FILL</property>
                   </packing>
                 </child>
@@ -319,8 +347,8 @@
                   <packing>
                     <property name="left_attach">1</property>
                     <property name="right_attach">2</property>
-                    <property name="top_attach">9</property>
-                    <property name="bottom_attach">10</property>
+                    <property name="top_attach">10</property>
+                    <property name="bottom_attach">11</property>
                     <property name="y_options">GTK_FILL</property>
                   </packing>
                 </child>

--- a/src/lxterminal.c
+++ b/src/lxterminal.c
@@ -1099,6 +1099,9 @@ static void terminal_settings_apply_to_term(LXTerminal * terminal, Term * term)
     vte_terminal_set_font_scale(VTE_TERMINAL(term->vte), terminal->scale);
     vte_terminal_set_scrollback_lines(VTE_TERMINAL(term->vte), setting->scrollback);
     vte_terminal_set_allow_bold(VTE_TERMINAL(term->vte), ! setting->disallow_bold);
+#if VTE_CHECK_VERSION (0, 52, 0)
+    vte_terminal_set_bold_is_bright(VTE_TERMINAL(term->vte), setting->bold_bright);
+#endif
     vte_terminal_set_cursor_blink_mode(VTE_TERMINAL(term->vte), ((setting->cursor_blink) ? VTE_CURSOR_BLINK_ON : VTE_CURSOR_BLINK_OFF));
     vte_terminal_set_cursor_shape(VTE_TERMINAL(term->vte), ((setting->cursor_underline) ? VTE_CURSOR_SHAPE_UNDERLINE : VTE_CURSOR_SHAPE_BLOCK));
     vte_terminal_set_audible_bell(VTE_TERMINAL(term->vte), setting->audible_bell);

--- a/src/preferences.c
+++ b/src/preferences.c
@@ -353,6 +353,17 @@ void terminal_preferences_dialog(GtkAction * action, LXTerminal * terminal)
     g_signal_connect(G_OBJECT(w), "toggled", 
         G_CALLBACK(preferences_dialog_allow_bold_toggled_event), setting);
 
+    w = GTK_WIDGET(gtk_builder_get_object(builder, "bold_bright"));
+#if VTE_CHECK_VERSION (0, 52, 0)
+    gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(w), setting->bold_bright);
+    g_signal_connect(G_OBJECT(w), "toggled", 
+        G_CALLBACK(preferences_dialog_generic_toggled_event), &setting->bold_bright);
+#else
+    gtk_widget_hide(w);
+    w = GTK_WIDGET(gtk_builder_get_object(builder, "label_bold_bright"));
+    gtk_widget_hide(w);
+#endif
+
     w = GTK_WIDGET(gtk_builder_get_object(builder, "cursor_blink"));
     gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(w), setting->cursor_blink);
     g_signal_connect(G_OBJECT(w), "toggled", 

--- a/src/setting.c
+++ b/src/setting.c
@@ -119,6 +119,9 @@ void print_setting()
     printf("Foreground color: %s\n", p);
     g_free(p);
     printf("Disallow bolding by VTE: %i\n", setting->disallow_bold);
+#if VTE_CHECK_VERSION (0, 52, 0)
+    printf("Bold is bright: %i\n", setting->bold_bright);
+#endif
     printf("Cursor blinks: %i\n", setting->cursor_blink);
     printf("Underline blinks: %i\n", setting->cursor_underline);
     printf("Audible bell: %i\n", setting->audible_bell);
@@ -204,6 +207,9 @@ void save_setting()
 
     g_free(p);
     g_key_file_set_boolean(setting->keyfile, GENERAL_GROUP, DISALLOW_BOLD, setting->disallow_bold);
+#if VTE_CHECK_VERSION (0, 52, 0)
+    g_key_file_set_boolean(setting->keyfile, GENERAL_GROUP, BOLD_BRIGHT, setting->bold_bright);
+#endif
     g_key_file_set_boolean(setting->keyfile, GENERAL_GROUP, CURSOR_BLINKS, setting->cursor_blink);
     g_key_file_set_boolean(setting->keyfile, GENERAL_GROUP, CURSOR_UNDERLINE, setting->cursor_underline);
     g_key_file_set_boolean(setting->keyfile, GENERAL_GROUP, AUDIBLE_BELL, setting->audible_bell);
@@ -409,6 +415,9 @@ color_preset_does_not_exist:
         }
 
         setting->disallow_bold = g_key_file_get_boolean(setting->keyfile, GENERAL_GROUP, DISALLOW_BOLD, NULL);
+#if VTE_CHECK_VERSION (0, 52, 0)
+        setting->bold_bright = g_key_file_get_boolean(setting->keyfile, GENERAL_GROUP, BOLD_BRIGHT, NULL);
+#endif
         setting->cursor_blink = g_key_file_get_boolean(setting->keyfile, GENERAL_GROUP, CURSOR_BLINKS, NULL);
         setting->cursor_underline = g_key_file_get_boolean(setting->keyfile, GENERAL_GROUP, CURSOR_UNDERLINE, NULL);
         setting->audible_bell = g_key_file_get_boolean(setting->keyfile, GENERAL_GROUP, AUDIBLE_BELL, NULL);

--- a/src/setting.h
+++ b/src/setting.h
@@ -30,6 +30,7 @@
 #define BG_COLOR "bgcolor"
 #define BG_ALPHA "bgalpha"
 #define DISALLOW_BOLD "disallowbold"
+#define BOLD_BRIGHT "boldbright"
 #define CURSOR_BLINKS "cursorblinks"
 #define CURSOR_UNDERLINE "cursorunderline"
 #define AUDIBLE_BELL "audiblebell"
@@ -96,6 +97,9 @@ typedef struct _setting {
 #endif
     const char * color_preset;        /* Color preset name */
     gboolean disallow_bold;     /* Disallow bolding by VTE */
+#if VTE_CHECK_VERSION (0, 52, 0)
+    gboolean bold_bright;       /* True if bold is bright */
+#endif
     gboolean cursor_blink;      /* True if cursor blinks */
     gboolean cursor_underline;      /* True if underline cursor; false if block cursor */
     gboolean audible_bell;      /* True if audible bell */


### PR DESCRIPTION
VTE 0.52 added "bold is bright" setting with the `vte_terminal_set_bold_is_bright` function, and subsequently turned it off by default in 0.56.

This adds the setting to LXTerminal as well as the UI to control it.