### PR TITLE
Use gtk_menu_popup_at_pointer if gtk >= 3.22

### DIFF
--- a/src/lxterminal.c
+++ b/src/lxterminal.c
@@ -994,8 +994,12 @@ static void terminal_show_popup_menu(VteTerminal * vte, GdkEventButton * event, 
         gtk_action_set_visible(action_open_url, term->matched_url != NULL);
     }
 
+#if GTK_CHECK_VERSION(3, 22, 0)
+    gtk_menu_popup_at_pointer(GTK_MENU(gtk_ui_manager_get_widget(manager, "/VTEMenu")), (GdkEvent *) event);
+#else
     gtk_menu_popup(GTK_MENU(gtk_ui_manager_get_widget(manager, "/VTEMenu")),
         NULL, NULL, NULL, NULL, event->button, event->time);
+#endif
 }
 
 /* Handler for "cursor-moved" signal on VTE */


### PR DESCRIPTION
gtk_menu_popup_at_pointer is introduced in gtk 3.22, and gtk_menu_popup
is marked as deprecated (and removed in gtk4 branch).
gtk_menu_popup_at_pointer also contains extra logic that fix popup
positioning in wayland so the menu won't be out of display.