### PR TITLE
Added "condensed tab" display option

### DIFF
--- a/data/lxterminal-preferences.glade
+++ b/data/lxterminal-preferences.glade
@@ -623,7 +623,7 @@
               <object class="GtkTable" id="table_display">
                 <property name="visible">True</property>
                 <property name="can_focus">False</property>
-                <property name="n_rows">7</property>
+                <property name="n_rows">8</property>
                 <property name="n_columns">2</property>
                 <property name="column_spacing">5</property>
                 <property name="row_spacing">3</property>
@@ -639,6 +639,19 @@
                   </packing>
                 </child>
                 <child>
+                  <object class="GtkLabel" id="label_condensed_tabs">
+                    <property name="visible">True</property>
+                    <property name="can_focus">False</property>
+                    <property name="xalign">1</property>
+                    <property name="label" translatable="yes">Condensed tabs</property>
+                  </object>
+                  <packing>
+                    <property name="top_attach">1</property>
+                    <property name="bottom_attach">2</property>
+                    <property name="y_options">GTK_FILL</property>
+                  </packing>
+                </child>
+                <child>
                   <object class="GtkLabel" id="label_scrollback_lines">
                     <property name="visible">True</property>
                     <property name="can_focus">False</property>
@@ -646,8 +659,8 @@
                     <property name="label" translatable="yes">Scrollback lines</property>
                   </object>
                   <packing>
-                    <property name="top_attach">1</property>
-                    <property name="bottom_attach">2</property>
+                    <property name="top_attach">2</property>
+                    <property name="bottom_attach">3</property>
                     <property name="y_options">GTK_FILL</property>
                   </packing>
                 </child>
@@ -659,8 +672,8 @@
                     <property name="label" translatable="yes">Hide scroll bar</property>
                   </object>
                   <packing>
-                    <property name="top_attach">3</property>
-                    <property name="bottom_attach">4</property>
+                    <property name="top_attach">4</property>
+                    <property name="bottom_attach">5</property>
                     <property name="y_options">GTK_FILL</property>
                   </packing>
                 </child>
@@ -672,8 +685,8 @@
                     <property name="label" translatable="yes">Hide menu bar</property>
                   </object>
                   <packing>
-                    <property name="top_attach">4</property>
-                    <property name="bottom_attach">5</property>
+                    <property name="top_attach">5</property>
+                    <property name="bottom_attach">6</property>
                     <property name="y_options">GTK_FILL</property>
                   </packing>
                 </child>
@@ -687,8 +700,8 @@
                   <packing>
                     <property name="left_attach">1</property>
                     <property name="right_attach">2</property>
-                    <property name="top_attach">4</property>
-                    <property name="bottom_attach">5</property>
+                    <property name="top_attach">5</property>
+                    <property name="bottom_attach">6</property>
                     <property name="y_options">GTK_FILL</property>
                   </packing>
                 </child>
@@ -711,6 +724,21 @@
                   </packing>
                 </child>
                 <child>
+                  <object class="GtkCheckButton" id="condensed_tabs">
+                    <property name="visible">True</property>
+                    <property name="can_focus">True</property>
+                    <property name="receives_default">False</property>
+                    <property name="draw_indicator">True</property>
+                  </object>
+                  <packing>
+                    <property name="left_attach">1</property>
+                    <property name="right_attach">2</property>
+                    <property name="top_attach">1</property>
+                    <property name="bottom_attach">2</property>
+                    <property name="y_options">GTK_FILL</property>
+                  </packing>
+                </child>
+                <child>
                   <object class="GtkSpinButton" id="scrollback_lines">
                     <property name="visible">True</property>
                     <property name="can_focus">True</property>
@@ -725,8 +753,8 @@
                   <packing>
                     <property name="left_attach">1</property>
                     <property name="right_attach">2</property>
-                    <property name="top_attach">1</property>
-                    <property name="bottom_attach">2</property>
+                    <property name="top_attach">2</property>
+                    <property name="bottom_attach">3</property>
                     <property name="y_options">GTK_FILL</property>
                   </packing>
                 </child>
@@ -740,8 +768,8 @@
                   <packing>
                     <property name="left_attach">1</property>
                     <property name="right_attach">2</property>
-                    <property name="top_attach">3</property>
-                    <property name="bottom_attach">4</property>
+                    <property name="top_attach">4</property>
+                    <property name="bottom_attach">5</property>
                     <property name="y_options">GTK_FILL</property>
                   </packing>
                 </child>
@@ -753,8 +781,8 @@
                     <property name="label" translatable="yes">Hide Close buttons</property>
                   </object>
                   <packing>
-                    <property name="top_attach">5</property>
-                    <property name="bottom_attach">6</property>
+                    <property name="top_attach">6</property>
+                    <property name="bottom_attach">7</property>
                     <property name="y_options">GTK_FILL</property>
                   </packing>
                 </child>
@@ -768,8 +796,8 @@
                   <packing>
                     <property name="left_attach">1</property>
                     <property name="right_attach">2</property>
-                    <property name="top_attach">5</property>
-                    <property name="bottom_attach">6</property>
+                    <property name="top_attach">6</property>
+                    <property name="bottom_attach">7</property>
                     <property name="y_options">GTK_FILL</property>
                   </packing>
                 </child>
@@ -781,8 +809,8 @@
                     <property name="label" translatable="yes">Hide mouse pointer</property>
                   </object>
                   <packing>
-                    <property name="top_attach">6</property>
-                    <property name="bottom_attach">7</property>
+                    <property name="top_attach">7</property>
+                    <property name="bottom_attach">8</property>
                     <property name="y_options">GTK_FILL</property>
                   </packing>
                 </child>
@@ -796,8 +824,8 @@
                   <packing>
                     <property name="left_attach">1</property>
                     <property name="right_attach">2</property>
-                    <property name="top_attach">6</property>
-                    <property name="bottom_attach">7</property>
+                    <property name="top_attach">7</property>
+                    <property name="bottom_attach">8</property>
                     <property name="y_options">GTK_FILL</property>
                   </packing>
                 </child>
@@ -809,8 +837,8 @@
                     <property name="label" translatable="yes">Default window size</property>
                   </object>
                   <packing>
-                    <property name="top_attach">2</property>
-                    <property name="bottom_attach">3</property>
+                    <property name="top_attach">3</property>
+                    <property name="bottom_attach">4</property>
                     <property name="y_options">GTK_FILL</property>
                   </packing>
                 </child>
@@ -872,8 +900,8 @@
                   <packing>
                     <property name="left_attach">1</property>
                     <property name="right_attach">2</property>
-                    <property name="top_attach">2</property>
-                    <property name="bottom_attach">3</property>
+                    <property name="top_attach">3</property>
+                    <property name="bottom_attach">4</property>
                     <property name="y_options">GTK_FILL</property>
                   </packing>
                 </child>

--- a/src/lxterminal.c
+++ b/src/lxterminal.c
@@ -1023,7 +1023,7 @@ static void terminal_vte_cursor_moved_event(VteTerminal * vte, Term * term)
             gtk_label_set_markup(GTK_LABEL(term->label),g_strconcat("<b>",currentcustomtitle,"</b>",NULL));
         } else {
             gtk_label_set_markup(GTK_LABEL(term->label),g_strconcat("<b>* ",vte_terminal_get_window_title(VTE_TERMINAL(vte)),"</b>",NULL));
-	}
+        }
     }
 }
 
@@ -1146,6 +1146,21 @@ static void terminal_settings_apply_to_term(LXTerminal * terminal, Term * term)
     else
     {
         gtk_widget_show(term->close_button);
+    }
+
+    /* Setup size of tab titles (either normal or condensed) */
+    if (setting->condensed_tabs)
+    {
+      PangoFontDescription *pfdesc = pango_font_description_new();
+
+      gtk_widget_set_size_request(GTK_WIDGET(term->close_button), 10, 10);
+      pango_font_description_set_size(pfdesc, PANGO_SCALE * 6);
+      gtk_widget_modify_font(GTK_WIDGET(term->label), pfdesc);
+    }
+    else
+    {
+      gtk_widget_set_size_request(GTK_WIDGET(term->close_button), -1, -1);
+      gtk_widget_modify_font(GTK_WIDGET(term->label), NULL);
     }
 }
 

--- a/src/preferences.c
+++ b/src/preferences.c
@@ -376,6 +376,11 @@ void terminal_preferences_dialog(GtkAction * action, LXTerminal * terminal)
     g_signal_connect(G_OBJECT(w), "changed", 
         G_CALLBACK(preferences_dialog_tab_position_changed_event), setting);
 
+    w = GTK_WIDGET(gtk_builder_get_object(builder, "condensed_tabs"));
+    gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(w), setting->condensed_tabs);
+    g_signal_connect(G_OBJECT(w), "toggled",
+        G_CALLBACK(preferences_dialog_generic_toggled_event), &setting->condensed_tabs);
+
     w = GTK_WIDGET(gtk_builder_get_object(builder, "scrollback_lines"));
     gtk_spin_button_set_value(GTK_SPIN_BUTTON(w), setting->scrollback);
     g_signal_connect(G_OBJECT(w), "value-changed", 

--- a/src/setting.c
+++ b/src/setting.c
@@ -123,6 +123,7 @@ void print_setting()
     printf("Underline blinks: %i\n", setting->cursor_underline);
     printf("Audible bell: %i\n", setting->audible_bell);
     printf("Tab position: %s\n", setting->tab_position);
+    printf("Condensed tabs: %i\n", setting->condensed_tabs);
     printf("Scrollback buffer size in lines: %i\n", setting->scrollback);
     printf("Hide scrollbar: %i\n", setting->hide_scroll_bar);
     printf("Hide menubar: %i\n", setting->hide_menu_bar);
@@ -208,6 +209,7 @@ void save_setting()
     g_key_file_set_boolean(setting->keyfile, GENERAL_GROUP, CURSOR_UNDERLINE, setting->cursor_underline);
     g_key_file_set_boolean(setting->keyfile, GENERAL_GROUP, AUDIBLE_BELL, setting->audible_bell);
     g_key_file_set_string(setting->keyfile, GENERAL_GROUP, TAB_POS, setting->tab_position);
+    g_key_file_set_boolean(setting->keyfile, GENERAL_GROUP, CONDENSED_TABS, setting->condensed_tabs);
     g_key_file_set_integer(setting->keyfile, GENERAL_GROUP, SCROLLBACK, setting->scrollback);
     g_key_file_set_integer(setting->keyfile, GENERAL_GROUP, GEOMETRY_COLUMNS, setting->geometry_columns);
     g_key_file_set_integer(setting->keyfile, GENERAL_GROUP, GEOMETRY_ROWS, setting->geometry_rows);
@@ -413,6 +415,7 @@ color_preset_does_not_exist:
         setting->cursor_underline = g_key_file_get_boolean(setting->keyfile, GENERAL_GROUP, CURSOR_UNDERLINE, NULL);
         setting->audible_bell = g_key_file_get_boolean(setting->keyfile, GENERAL_GROUP, AUDIBLE_BELL, NULL);
         setting->tab_position = g_key_file_get_string(setting->keyfile, GENERAL_GROUP, TAB_POS, NULL);
+        setting->condensed_tabs = g_key_file_get_boolean(setting->keyfile, GENERAL_GROUP, CONDENSED_TABS, NULL);
         setting->scrollback = g_key_file_get_integer(setting->keyfile, GENERAL_GROUP, SCROLLBACK, &error);
         if (error && (error->code == G_KEY_FILE_ERROR_KEY_NOT_FOUND))
         {   

--- a/src/setting.h
+++ b/src/setting.h
@@ -34,6 +34,7 @@
 #define CURSOR_UNDERLINE "cursorunderline"
 #define AUDIBLE_BELL "audiblebell"
 #define TAB_POS "tabpos"
+#define CONDENSED_TABS "condensedtabs"
 #define SCROLLBACK "scrollback"
 #define GEOMETRY_COLUMNS "geometry_columns"
 #define GEOMETRY_ROWS "geometry_rows"
@@ -100,6 +101,7 @@ typedef struct _setting {
     gboolean cursor_underline;      /* True if underline cursor; false if block cursor */
     gboolean audible_bell;      /* True if audible bell */
     char * tab_position;        /* Position of tabs on main window (top, bottom, left, right) */
+    gboolean condensed_tabs;            /* Whether tab labels are small or normal */
     gint scrollback;            /* Scrollback buffer size in lines */
     gint geometry_columns;
     gint geometry_rows;


### PR DESCRIPTION
This patch adds a "preferences" setting for reducing the size of window labels in the multi-tab display.

In the normal lxterminal setup, these window tabs can occupy a significant amount of space, which can be wasteful when used on a small screen. With this patch, the size of the tabs can be reduced to only about 20 pixels in height, which is big enough to read, but saves more space for the window content.

![geom-dialog](https://user-images.githubusercontent.com/8206669/80947202-89f94d00-8de7-11ea-9844-8b7e16821956.png)
![tabs-comparison](https://user-images.githubusercontent.com/8206669/81004021-a62ad780-8e43-11ea-972c-82c1506c2cb5.png)
