### PR TITLE
Have multiple command line --command= options for multiple commands

### DIFF
--- a/man/lxterminal.xml
+++ b/man/lxterminal.xml
@@ -24,8 +24,7 @@
   </refsynopsisdiv>
   <refsect1>    <title>DESCRIPTION</title>
 
-    <para>This manual page documents briefly the
-      <command>lxterminal</command> command.</para>
+    <para>This manual page documents the <command>lxterminal</command> command.</para>
 
     <para><command>lxterminal</command> is a program that provides a terminal
     emulator
@@ -42,17 +41,22 @@
     </para>
 
     <variablelist>      <varlistentry>        <term>	  <option>-e <replaceable>STRING</replaceable></option>
-          <option>--command=<replaceable>STRING</replaceable></option>
           <option>--command <replaceable>STRING</replaceable></option>
+          <option>--command=<replaceable>STRING</replaceable></option>
 
         </term>
-        <listitem>          <para>This option specifies the program (and its command line arguments) to be run in the terminal.
-Except in the <option>--command=</option> form, this must be the last option on the command line.</para>
+	<listitem>          <para>These options specifies the program (and its command line arguments) to be run in the terminal. Except in the <option>--command=</option> form, this must be the last option on the command line, since the following arguments, if there are any, will be considered related to the program to be run. Multiple <option>command=</option> options, each specify a single program (and its command line arguments), create multiple tabs, each running the respective program. New tabs will be created as necessary, after all the explictly requested <option>tabs=</option> will be exhausted.</para>
         </listitem>
       </varlistentry>
       <varlistentry>	<term>	  <option>--geometry=<replaceable>CHARACTERS</replaceable>x<replaceable>LINES</replaceable></option>
 	</term>
 	<listitem>	  <para>Set the terminal's size in characters and lines.</para>
+	</listitem>
+      </varlistentry>
+      <varlistentry>	<term>	  <option>-h</option>
+	  <option>--help</option>
+	</term>
+	<listitem>	  <para>Prints a short help message, and exit.</para>
 	</listitem>
       </varlistentry>
       <varlistentry>	<term>	  <option>-l</option>
@@ -61,17 +65,62 @@ Except in the <option>--command=</option> form, this must be the last option on 
 	<listitem>	  <para>Executes login shell.</para>
 	</listitem>
       </varlistentry>
-      <varlistentry>	<term>	  <option>-t <replaceable>NAME[,NAME[,NAME[...]]]</replaceable></option>
-	  <option>--title=<replaceable>NAME[,NAME[,NAME[...]]]</replaceable></option>
-	  <option>--tabs=<replaceable>NAME[,NAME[,NAME[...]]]</replaceable></option>
+      <varlistentry>	<term>	  <option>-T <replaceable>NAME</replaceable></option>
+	  <option>-t <replaceable>NAME</replaceable></option>
+	  <option>--title=<replaceable>NAME</replaceable></option>
+	  <option>--tabs=<replaceable>[NAME[,NAME[...]]]</replaceable></option>
 	</term>
-	<listitem>	  <para>Set the terminal's title. Use comma for multiple tabs.</para>
+	<listitem>	  <para>Set the terminal's title. Comma separated multiple titles create multiple tabs only with the <option>--tabs=</option> form.</para>
 	</listitem>
       </varlistentry>
       <varlistentry>        <term>          <option>--working-directory=<replaceable>DIRECTORY</replaceable></option>
         </term>
         <listitem>          <para>Set the terminal's working directory.</para>
         </listitem>
+      </varlistentry>
+      <varlistentry>	<term>	  <option>-v</option>
+	  <option>--version</option>
+	</term>
+	<listitem>	  <para>Prints the program version, and exit.</para>
+	</listitem>
+      </varlistentry>
+    </variablelist>
+  </refsect1>
+
+  <refsect1>    <title>EXAMPLES, AND MORE DETAILS</title>
+
+    <variablelist>       <varlistentry>	<term>	  <option>The hidden tab</option>
+        </term>
+	<listitem>	  <para>A hidden tab is created when <option>--tabs</option>, or any <option>--command</option> variant, is requested, with no more than one command, or no more than one tab, is specified. For example,</para>
+		<para><command>lxterminal</command> --tabs= --no-remote</para>
+		<para>This hidden tab can be revealed when the <command>lxterminal</command> is running. For example, when requesting a new tab with the Shift+Ctrl+T combination keys.</para>
+	</listitem>
+      </varlistentry>
+      <varlistentry>	<term>	  <option>The command examples</option> 	</term><listitem>
+<para>For display puposes, the command examples might be broken into more than one line. When actually using the examples, commands should be entered in a single line. Or have line breaks according to the usual shell conventions.</para>
+		    <para>All command examples here use <option>--no-remote</option> to avoid interaction with possibly running <command>lxterminal</command>s.</para>
+	</listitem>
+      </varlistentry>
+	    <varlistentry>	<term>	  <option>A short lived process is requested in the command line</option> 	</term>
+		    <listitem>      <para>Consider</para>
+			    <para><command>lxterminal</command> --no-remote --command=&apos;/bin/bash -c &quot;echo This window will be closed after you will press enter. ; read -p \&quot;Do press the &lt;enter&gt; key.\&quot; &quot; &apos;</para>
+			    <para>This example emphasizes a limitaion of running commands from the <command>lxterminal</command> command line. As a result, the feature to run a command from the <command>lxterminal</command> command line is much more useful for processes that exit by the user explicit request. Such as an interactive shell. A short lived process does work. Only that it is fast enough to make the window, or the tab, closed before the user can pay attention. For a short lived process, such as</para>
+			    <para><command>lxterminal</command> --no-remote --tabs=ls,"Midnight Commander" --command=ls --command=mc</para><para>
+					    , the user must have indirect means to inspect the outcome of the <option>ls</option> command, if he wishes to. Such as redirecting the output to a file.</para>
+	</listitem>
+      </varlistentry>
+	    <varlistentry>	<term>	  <option>Multiple occurences of the same option</option> 	</term>
+		    <listitem>  
+			    <para><command>lxterminal</command> --no-remote --tabs=&apos;1st tab&apos;,&quot;2nd tab&quot; --tabs= --no-remote</para>
+			    <para>In contrast to many other applications, repeating a command line <option>option</option> is not an error. With some <option>option</option>s, the right most occurence overrides previous ocuurences. But there are exceptions. The left most <option>--command=</option> will always be executed in the 1st tab. Unless <option>-e</option>, or <option>command</option>, was specified. As stated earlier, multiple <option>command=</option> are commulative in the sense that each will be executed. Just try out if it is a concern for you. The behaviour is deterministic.</para> 
+	</listitem>
+      </varlistentry>
+	    <varlistentry>	<term>	  <option>Comma is a separator for --tabs=</option> 	</term>
+		    <listitem>  
+			    <para>The comma character, &apos;,&apos;, is used as the separator for the titles to the <option>--tabs=</option> option.</para>
+			    <para><command>lxterminal</command> --tabs=&quot;midnight commander,2nd tab&quot; --command=mc --no-remote</para>
+			    <para>There is no way to insert a comma character in the titles to be displayed by <option>--tabs=</option>. The comma character can be used for the similar options for giving a title, such as <option>-T</option>. But these other options do not offer mutltiple tabs.</para>
+	</listitem>
       </varlistentry>
     </variablelist>
   </refsect1>

--- a/src/lxterminal.c
+++ b/src/lxterminal.c
@@ -97,13 +97,14 @@ static gboolean terminal_vte_button_press_event(VteTerminal * vte, GdkEventButto
 static void terminal_settings_apply_to_term(LXTerminal * terminal, Term * term);
 static Term * terminal_new(LXTerminal * terminal, const gchar * label, const gchar * pwd, gchar * * env, gchar * * exec);
 static void terminal_set_geometry_hints(Term * term, GdkGeometry * geometry);
-static void terminal_new_tab(LXTerminal * terminal, const gchar * label);
+static void terminal_new_tab(LXTerminal * terminal, const gchar * label, const gchar * cmd);
 static void terminal_free(Term * term);
 static void terminal_menubar_initialize(LXTerminal * terminal);
 static void terminal_menu_accelerator_update(LXTerminal * terminal);
 static void terminal_settings_apply(LXTerminal * terminal);
 static void terminal_update_menu_shortcuts(Setting * setting);
 static void terminal_initialize_menu_shortcuts(Setting * setting);
+static void terminal_process_requested_command(gchar * * * const command, const gint cmd_len, const gboolean login_shell);
 
 /* Menu accelerator saved when the user disables it. */
 static char * saved_menu_accelerator = NULL;
@@ -113,8 +114,10 @@ static gchar usage_display[] = {
     "Usage:\n"
     "  lxterminal [Options...] - LXTerminal is a terminal emulator\n\n"
     "Options:\n"
-    "  -e, --command=STRING             Execute the argument to this option inside the terminal\n"
+    "  --command=STRING [--command=STRING [...]],\n"
+    "    -e STRING, --command STRING    Execute the argument to this option inside the terminal\n"
     "  --geometry=COLUMNSxROWS          Set the terminal's size\n"
+    "  -h, --help                       This help text\n"
     "  -l, --loginshell                 Execute login shell\n"
     "  -t, -T, --title=,\n"
     "    --tabs=NAME[,NAME[,NAME[...]]] Set the terminal's title\n"
@@ -293,7 +296,8 @@ static void terminal_initialize_switch_tab_accelerator(Term * term)
     {
         /* Formulate the accelerator name. */
         char switch_tab_accel[1 + 3 + 1 + 1 + 1]; /* "<ALT>n" */
-        sprintf(switch_tab_accel, "<ALT>%d", term->index + 1);
+	/* Casting to unsigned, and %10, to shut off a compilation warning. */
+        sprintf(switch_tab_accel, "<ALT>%d", (guint)(term->index + 1)%10);
 
         /* Parse the accelerator name. */
         guint key;
@@ -373,7 +377,7 @@ static void terminal_new_window_activate_event(GtkAction * action, LXTerminal * 
  * Open a new tab. */
 static void terminal_new_tab_activate_event(GtkAction * action, LXTerminal * terminal)
 {
-    terminal_new_tab(terminal, NULL);
+    terminal_new_tab(terminal, NULL, NULL);
 }
 
 static void terminal_set_geometry_hints(Term *term, GdkGeometry *geometry)
@@ -410,7 +414,7 @@ static void terminal_save_size(LXTerminal * terminal)
     terminal->row = vte_terminal_get_row_count(VTE_TERMINAL(term->vte));
 }
 
-static void terminal_new_tab(LXTerminal * terminal, const gchar * label)
+static void terminal_new_tab(LXTerminal * terminal, const gchar * label, const gchar * cmd)
 {
     Term * term;
     gchar * proc_cwd = terminal_get_current_dir(terminal);
@@ -419,21 +423,14 @@ static void terminal_new_tab(LXTerminal * terminal, const gchar * label)
      * If the working directory was determined above, use it; otherwise default to the working directory of the process.
      * Create the new terminal. */
 
-    if (terminal->login_shell)
+    gint cmd_len = 0;
+    gchar * * exec = NULL;
+    if (cmd != NULL)
     {
-        /* Create a login shell, this should be cleaner. */
-        gchar * * exec = g_malloc(3 * sizeof(gchar *));
-        exec[0] = g_strdup(terminal_get_preferred_shell());
-        char * shellname = g_path_get_basename(exec[0]);
-        exec[1] = g_strdup_printf("-%s", shellname);
-        g_free(shellname);
-        exec[2] = NULL;
-        term = terminal_new(terminal, label, proc_cwd, NULL, exec);
+        g_shell_parse_argv(cmd, &cmd_len, &exec, NULL);
     }
-    else
-    {
-        term = terminal_new(terminal, label, proc_cwd, NULL, NULL);
-    }
+    terminal_process_requested_command(&exec, cmd_len, terminal->login_shell);
+    term = terminal_new(terminal, label, proc_cwd, NULL, exec);
     g_free(proc_cwd);
 
     /* Add a tab to the notebook and the "terms" array. */
@@ -1315,6 +1312,7 @@ static Term * terminal_new(LXTerminal * terminal, const gchar * label, const gch
         exec[1] = g_path_get_basename(exec[0]);
         exec[2] = NULL;
     }
+    term->command = exec;
 
 #if VTE_CHECK_VERSION (0, 38, 0)
     vte_terminal_spawn_sync(
@@ -1342,7 +1340,6 @@ static Term * terminal_new(LXTerminal * terminal, const gchar * label, const gch
                     &term->pid,
                     NULL);
 #endif
-    g_strfreev(exec);
 
     /* Connect signals. */
     g_signal_connect(G_OBJECT(term->tab), "button-press-event", G_CALLBACK(terminal_tab_button_press_event), term);
@@ -1365,6 +1362,7 @@ static Term * terminal_new(LXTerminal * terminal, const gchar * label, const gch
 /* Deallocate a Term structure. */
 static void terminal_free(Term * term)
 {
+    g_strfreev(term->command);
     g_free(term->matched_url);
     if ((GTK_IS_ACCEL_GROUP(term->parent->accel_group)) && (term->closure != NULL))
     {
@@ -1431,7 +1429,7 @@ gboolean lxterminal_process_arguments(gint argc, gchar * * argv, CommandArgument
     arguments->executable = argv[0];
 
     char * * argv_cursor = argv;
-    gint cmd_len;
+    gint num___commandEqual = 0; /* ___commandEqual for _--command= */
 
     while (argc > 1)
     {
@@ -1439,19 +1437,23 @@ gboolean lxterminal_process_arguments(gint argc, gchar * * argv, CommandArgument
         argv_cursor ++;
         char * argument = *argv_cursor;
 
-        /* --command=<command> */
+        /* --command= */
         if (strncmp(argument, "--command=", 10) == 0)
         {
-            g_strfreev(arguments->command);
-            g_shell_parse_argv(&argument[10], &cmd_len, &arguments->command, NULL);
+            arguments->commands = 
+                g_realloc(arguments->commands,
+                          (num___commandEqual + 2) * sizeof(gchar *));
+            arguments->commands[num___commandEqual] = &argument[10];
+            num___commandEqual ++;
+            arguments->commands[num___commandEqual] = NULL;
         }
 
         /* -e <rest of arguments>, --command <rest of arguments>
          * The <rest of arguments> behavior is demanded by distros who insist on this xterm feature. */
         else if ((strcmp(argument, "--command") == 0) || (strcmp(argument, "-e") == 0))
         {
-            if(arguments->command != NULL) g_strfreev(arguments->command);
-            cmd_len = 0;
+            g_strfreev(arguments->command);
+            gint cmd_len = 0;
             arguments->command = g_malloc(argc * sizeof(gchar *));
 
             while (argc > 1)
@@ -1521,7 +1523,7 @@ gboolean lxterminal_process_arguments(gint argc, gchar * * argv, CommandArgument
             arguments->working_directory = &argument[20];
         }
 
-    /* --no-remote: Do not accept or send remote commands */
+        /* --no-remote: Do not accept or send remote commands */
         else if (strcmp(argument, "--no-remote") == 0) {
             arguments->no_remote = TRUE;
         }
@@ -1536,28 +1538,35 @@ gboolean lxterminal_process_arguments(gint argc, gchar * * argv, CommandArgument
         else {
             printf("%s\n", usage_display);
             return FALSE;
+        }
     }
-    }
+    return TRUE;
+}
+
+/* Furthere process a command before executing it. Handle out of path, and login shell.*/
+static void terminal_process_requested_command(gchar * * * const command, const gint cmd_len, const gboolean login_shell)
+{
+    gboolean force_login_shell = FALSE;
     /* Handle --loginshell. */
-    if (arguments->command != NULL && cmd_len <= 2) {
+    if (*command != NULL && cmd_len <= 2) {
 	/* Force using login shell if it has only 1 command, and command is not
 	 * in PATH. */
-        gchar * program_path = g_find_program_in_path(arguments->command[0]);
+        gchar * program_path = g_find_program_in_path((*command)[0]);
         if (program_path == NULL) {
-            arguments->login_shell = TRUE;
+            force_login_shell = TRUE;
         }
         g_free(program_path);
     }
-    if (arguments->login_shell == TRUE)
+    if (login_shell == TRUE || force_login_shell == TRUE)
     {
         const gchar * shell = terminal_get_preferred_shell();
         gchar * shellname = g_path_get_basename(shell);
-        if (arguments->command == NULL)
+        if (*command == NULL)
         {
-            arguments->command = g_malloc(3 * sizeof(gchar *));
-            arguments->command[0] = g_strdup(shell);
-            arguments->command[1] = g_strdup_printf("-%s", shellname);
-            arguments->command[2] = NULL;
+            *command = g_malloc(3 * sizeof(gchar *));
+            (*command)[0] = g_strdup(shell);
+            (*command)[1] = g_strdup_printf("-%s", shellname);
+            (*command)[2] = NULL;
         }
         else
         {
@@ -1565,26 +1574,25 @@ gboolean lxterminal_process_arguments(gint argc, gchar * * argv, CommandArgument
             tmp[0] = g_strdup(shell);
             tmp[1] = g_strdup_printf("-%s", shellname);
             tmp[2] = g_strdup("-c");
-            memcpy((tmp + 3), arguments->command, cmd_len * sizeof(gchar *));
+            memcpy((tmp + 3), *command, cmd_len * sizeof(gchar *));
             tmp[cmd_len + 3] = NULL;
-            g_free(arguments->command);
-            arguments->command = tmp;
+            g_free(*command);
+            *command = tmp;
         }
         g_free(shellname);
     }
     else
     {
-        if(arguments->command != NULL)
+        if (*command != NULL)
         {
             gchar * * tmp = g_malloc((cmd_len + 2) * sizeof(gchar *));
-            tmp[0] = g_strdup(arguments->command[0]);
-            memcpy((tmp + 1), arguments->command, cmd_len * sizeof(gchar *));
+            tmp[0] = g_strdup((*command)[0]);
+            memcpy((tmp + 1), *command, cmd_len * sizeof(gchar *));
             tmp[cmd_len + 1] = NULL;
-            g_free(arguments->command);
-            arguments->command = tmp;
+            g_free(*command);
+            *command = tmp;
         }
     }
-    return TRUE;
 }
 
 /* Initialize a new LXTerminal.
@@ -1670,12 +1678,27 @@ LXTerminal * lxterminal_initialize(LXTermWindow * lxtermwin, CommandArguments * 
     {
         local_working_directory = g_get_current_dir();
     }
+    gchar * * command = NULL;
+    gint cmd_len = 0;
+    if (arguments->command != NULL)
+    {
+        command = g_strdupv(arguments->command);
+        /* This duplication is meant to help unify the rest of the code. 
+         * In particular, when freeing the memory of the --commands= options,
+         * there will be no need to differentiate the --command case. */
+        cmd_len = (gint)g_strv_length(arguments->command);
+    }
+    else if (arguments->commands != NULL)
+    {
+        g_shell_parse_argv(arguments->commands[0], &cmd_len, &command, NULL);
+    }
+    terminal_process_requested_command(&command, cmd_len, arguments->login_shell);
     Term * term = terminal_new(
         terminal,
         ((arguments->title != NULL) ? arguments->title : NULL),
         ((arguments->working_directory != NULL) ? arguments->working_directory : local_working_directory),
         NULL,
-        arguments->command);
+        command);
     g_free(local_working_directory);
 
     /* Set window title. */
@@ -1761,18 +1784,37 @@ LXTerminal * lxterminal_initialize(LXTermWindow * lxtermwin, CommandArguments * 
     /* Update terminal settings. */
     terminal_settings_apply(terminal);
 
-    if (arguments->tabs != NULL && arguments->tabs[0] != '\0')
+    if (arguments->tabs != NULL && arguments->tabs[0] != '\0'
+                || arguments->commands != NULL)
     {
-        /* use token to destructively slice tabs to different tab names */
-        char * token = strtok(arguments->tabs, ",");
-        term->user_specified_label = TRUE;
-        gtk_label_set_text(GTK_LABEL(term->label), token);
-        token = strtok(NULL, ",");
-
-        while (token != NULL && token[0] != '\0')
+        gchar * tab = NULL;
+        if (arguments->tabs != NULL && arguments->tabs[0] != '\0')
         {
-            terminal_new_tab(terminal, token);
-            token = strtok(NULL, ",");
+            /* Use tab to destructively slice tabs to different tab names */
+            tab = strtok(arguments->tabs, ",");
+            term->user_specified_label = TRUE;
+            gtk_label_set_text(GTK_LABEL(term->label), tab);
+	    /* Initially, the 1st tab is hidden */ 
+            tab = strtok(NULL, ",");
+        }
+        gchar * * cmd = arguments->commands;
+        if (cmd != NULL)
+        {
+            if (arguments->command == NULL)
+            {
+                cmd ++;  /* Initialy, hidden tab runs 1st command from --command=. */
+            }
+        }
+
+        while (tab != NULL && tab[0] != '\0' || cmd != NULL && *cmd != NULL)
+        {
+            terminal_new_tab(terminal, tab, cmd != NULL ? *cmd : NULL);
+            if (tab != NULL && tab[0] != '\0')
+                tab = strtok(NULL, ",");
+            if (cmd != NULL && *cmd != NULL)
+            {
+                cmd ++;
+            }
         }
     }
 

--- a/src/lxterminal.h
+++ b/src/lxterminal.h
@@ -70,6 +70,7 @@ typedef struct _term {
     GtkWidget * scrollbar;          /* Scroll bar, child of horizontal box */
     GPid pid;                                   /* Process ID of the process that has this as its terminal */
     GClosure * closure;             /* Accelerator structure */
+    gchar * * command;              /* Memory allocated by glib */
     gchar * matched_url;
     gboolean open_menu_on_button_release;
     gulong exit_handler_id;
@@ -79,6 +80,7 @@ typedef struct _term {
 typedef struct _command_arguments {
     char * executable;              /* Value of argv[0]; points into argument vector */
     gchar * * command;              /* Value of -e, --command; memory allocated by glib */
+    gchar * * commands;             /* Accumulated values of --command=; pointers into argument vector */
     int geometry_bitmask;
     unsigned int geometry_columns;           /* Value of --geometry */
     unsigned int geometry_rows;


### PR DESCRIPTION
The reader is kindly asked to pay attention for the ``s`` letter, or absent of, and to the ``=`` character, or absent of, in the seemingly no different ``--command``, ``--command=`` and ``--commands=`` terms. In what follows, these 3 different terms are totally different. 
With the current stable implementation, with multiple ``--command=`` command line options, only the last one was used. It override the previous occurrences of ``--command=``. As promised at https://github.com/lxde/lxterminal/pull/98#issuecomment-888600876, this code modifies that. With it, all the commands specified with ``--command=`` option will run. Each one at a different tab. Each command is automatically paired with a tab. After exhausting existing tabs, new tabs will be automatically created.

This feature does not lift the basic limitation of commands in lxterminal command line. Which is, that short lived processes makes the tab they ran within, or the whole window in case of only short lived processes, to get closed as soon as the short lived processes have terminated. This limitation is shortly described in the modified man page.

This patch constitutes of modifying 3 files:
1. src/lxterminal.h
2. src/lxterminal.c
3. man/lxterminal.xml

Lightly tested.

The modification of lxterminal.xml, beside describing the new behavior of the --command= option, also describes, in some length, some pitfalls of lxterminal.
