### PR TITLE
Fix background echoes when window is semitransparent

### DIFF
--- a/src/lxterminal.c
+++ b/src/lxterminal.c
@@ -1787,6 +1787,27 @@ static void terminal_settings_apply(LXTerminal * terminal)
     /* Reinitialize "composited". */
     terminal->rgba = gdk_screen_is_composited(gtk_widget_get_screen(terminal->window));
 
+    #if GTK_CHECK_VERSION (2, 90, 8)
+    /* Found in vteapp as a workaround.  Related bug:
+     * https://bugzilla.gnome.org/show_bug.cgi?format=multiple&id=729884 */
+    gboolean has_transparency = setting->background_color.alpha < 1.0;
+    gtk_widget_set_app_paintable(
+        GTK_WIDGET(terminal->window), has_transparency);
+
+    /* De-transarent box */
+    GtkCssProvider* box_css_provider = gtk_css_provider_new();
+    gtk_css_provider_load_from_data(box_css_provider,
+        "box{background-color:@theme_bg_color;}",
+        -1, NULL
+    );
+
+    GtkStyleContext* box_style_ctx =
+        gtk_widget_get_style_context(GTK_WIDGET(terminal->box));
+    gtk_style_context_add_provider(
+        box_style_ctx, box_css_provider,
+        GTK_STYLE_PROVIDER_PRIORITY_APPLICATION);
+    #endif
+
     /* Update tab position. */
     terminal->tab_position = terminal_tab_get_position_id(setting->tab_position);
     terminal_tab_set_position(terminal->notebook, terminal->tab_position);

--- a/src/lxterminal.c
+++ b/src/lxterminal.c
@@ -1782,21 +1782,23 @@ LXTerminal * lxterminal_initialize(LXTermWindow * lxtermwin, CommandArguments * 
 /* Apply new settings to a terminal. */
 static void terminal_settings_apply(LXTerminal * terminal)
 {
+    Setting * setting = get_setting();
+
     /* Reinitialize "composited". */
     terminal->rgba = gdk_screen_is_composited(gtk_widget_get_screen(terminal->window));
 
     /* Update tab position. */
-    terminal->tab_position = terminal_tab_get_position_id(get_setting()->tab_position);
+    terminal->tab_position = terminal_tab_get_position_id(setting->tab_position);
     terminal_tab_set_position(terminal->notebook, terminal->tab_position);
 
     /* Update menu accelerators. */
     terminal_menu_accelerator_update(terminal);
 
     /* disable mnemonics if <ALT>n is diabled */
-    g_object_set(gtk_settings_get_default(), "gtk-enable-mnemonics", !get_setting()->disable_alt, NULL);
+    g_object_set(gtk_settings_get_default(), "gtk-enable-mnemonics", !setting->disable_alt, NULL);
 
     /* Hide or show menubar. */
-    if (get_setting()->hide_menu_bar)
+    if (setting->hide_menu_bar)
     {
         gtk_widget_hide(terminal->menu);
     }


### PR DESCRIPTION
We received bug reports from https://bugs.debian.org/978629 that the background will have residues when the background color is semitransparent.

I found one workaround in vte example app that we need to set gtk_widget_set_app_paintable to the window, but if this is added, the window background is missing, causing the background of the other elements in the window being transparent, so the background color of the vbox is set to avoid the issue.

Asking @FinboySlick for review.