### PR TITLE
Add a new default colour palette

### DIFF
--- a/src/setting.c
+++ b/src/setting.c
@@ -70,6 +70,17 @@ ColorPreset color_presets[] = {
         }
     },
     {
+        .name = "Uniform Lightness",
+        .background_color = "#000000",
+        .foreground_color = "#ffffff",
+        .palette = {
+            "#000000", "#ff6866", "#46bf00", "#aba700",
+            "#709dff", "#d969f5", "#00b7be", "#bcbcbc",
+            "#777777", "#ffb18f", "#00ed7b", "#b5d900",
+            "#bbc0ff", "#ffa5df", "#3cdbff", "#ffffff"
+        }
+    },
+    {
         .name = "Solarized Dark",
         .background_color = "#002b36",
         .foreground_color = "#839496",


### PR DESCRIPTION
# Problem description

With the current default, VGA, the colours differ significantly in lightness. Blue is especially dark and can therefore be difficult to read on a black background.

# Proposed changes

The new default colours have a more uniform lightness, and hand-picked hue and chroma values to make them distinguishable from each other. The foreground colour is white and not grey to increase the contrast of most of the text shown in the terminal.

## Current and proposed default palette in action
`echo; for i in {30..47} {89..107}; do echo $'\u001b'"[${i}m Colour $i "$'\u001b'"[m"; done | column; echo`
![current colours](https://github.com/lxde/lxterminal/assets/3192173/b8a0896e-896f-4b89-8265-0823692c1c4c)
![proposed colours](https://github.com/lxde/lxterminal/assets/3192173/0d1f821f-1f75-47e8-9a0a-b29bc2ceaf47)

## Lightness and hue values of the current and proposed default palette
![current](https://github.com/lxde/lxterminal/assets/3192173/8e5d1db7-cb5f-49e4-a34f-a72e445d16f4)
![proposed](https://github.com/lxde/lxterminal/assets/3192173/c00b201c-a5ad-4806-8311-178562fcd662)

# Additional notes

Which palette looks good depends on personal preference, the display, viewing environment, windows shown next to the terminal, and more. 

Please test if my change works correctly; I tried to test it myself but strange things happened with and without the commit, perhaps because I have a system-wide LXTerminal, too.