### PR TITLE
Implement configuration profiles

### DIFF
--- a/man/lxterminal.1
+++ b/man/lxterminal.1
@@ -75,7 +75,7 @@ Set the terminal\*(Aqs working directory\&.
 .PP
 \fB\-\-profile=\fR\fB\fINAME\fR\fR
 .RS 4
-If set, then all instances of lxterminal invoked in the same way will share a config file named lxterminal-PROFILE.conf\&.
+If set, then all instances of lxterminal invoked in the same way will share a config file named lxterminal-NAME.conf\&.
 .RE
 .SH "AUTHOR"
 .PP
@@ -90,7 +90,7 @@ General Public License, Version 2 any later version published by the Free Softwa
 On Debian systems, the complete text of the GNU General Public License can be found in /usr/share/common\-licenses/GPL\&.
 .SH "FILES"
 .PP
-The configuration file can be found in ~/\&.config/lxterminal/lxterminal\&.conf, or lxterminal-PROFILE.conf\&.
+The configuration file can be found in ~/\&.config/lxterminal/lxterminal\&.conf, or lxterminal-NAME.conf\&.
 .SH "AUTHOR"
 .PP
 \fBYing\-Chun Liu\fR

--- a/man/lxterminal.1
+++ b/man/lxterminal.1
@@ -72,6 +72,11 @@ Set the terminal\*(Aqs title\&. Use comma for multiple tabs\&.
 .RS 4
 Set the terminal\*(Aqs working directory\&.
 .RE
+.PP
+\fB\-\-profile=\fR\fB\fINAME\fR\fR
+.RS 4
+If set, then all instances of lxterminal invoked in the same way will share a config file named lxterminal-PROFILE.conf\&.
+.RE
 .SH "AUTHOR"
 .PP
 This manual page was written by paulliu
@@ -85,7 +90,7 @@ General Public License, Version 2 any later version published by the Free Softwa
 On Debian systems, the complete text of the GNU General Public License can be found in /usr/share/common\-licenses/GPL\&.
 .SH "FILES"
 .PP
-The configuration file can be found in ~/\&.config/lxterminal/lxterminal\&.conf\&.
+The configuration file can be found in ~/\&.config/lxterminal/lxterminal\&.conf, or lxterminal-PROFILE.conf\&.
 .SH "AUTHOR"
 .PP
 \fBYing\-Chun Liu\fR

--- a/man/lxterminal.xml
+++ b/man/lxterminal.xml
@@ -75,7 +75,7 @@ Except in the <option>--command=</option> form, this must be the last option on 
       </varlistentry>
       <varlistentry>        <term>          <option>--profile=<replaceable>NAME</replaceable></option>
         </term>
-        <listitem>          <para>If set, then all instances of lxterminal invoked in the same way will share a config file named lxterminal-PROFILE.conf.</para>
+        <listitem>          <para>If set, then all instances of lxterminal invoked in the same way will share a config file named lxterminal-NAME.conf.</para>
         </listitem>
       </varlistentry>
     </variablelist>
@@ -97,6 +97,6 @@ Except in the <option>--command=</option> form, this must be the last option on 
 
   <refsect1>    <title>FILES</title>
 
-    <para>The configuration file can be found in ~/.config/lxterminal/lxterminal.conf, or lxterminal-PROFILE.conf.</para>
+    <para>The configuration file can be found in ~/.config/lxterminal/lxterminal.conf, or lxterminal-NAME.conf.</para>
 
   </refsect1></refentry>

--- a/man/lxterminal.xml
+++ b/man/lxterminal.xml
@@ -73,6 +73,11 @@ Except in the <option>--command=</option> form, this must be the last option on 
         <listitem>          <para>Set the terminal's working directory.</para>
         </listitem>
       </varlistentry>
+      <varlistentry>        <term>          <option>--profile=<replaceable>NAME</replaceable></option>
+        </term>
+        <listitem>          <para>If set, then all instances of lxterminal invoked in the same way will share a config file named lxterminal-PROFILE.conf.</para>
+        </listitem>
+      </varlistentry>
     </variablelist>
   </refsect1>
 
@@ -92,6 +97,6 @@ Except in the <option>--command=</option> form, this must be the last option on 
 
   <refsect1>    <title>FILES</title>
 
-    <para>The configuration file can be found in ~/.config/lxterminal/lxterminal.conf.</para>
+    <para>The configuration file can be found in ~/.config/lxterminal/lxterminal.conf, or lxterminal-PROFILE.conf.</para>
 
   </refsect1></refentry>

--- a/src/lxterminal.c
+++ b/src/lxterminal.c
@@ -1546,7 +1546,8 @@ gboolean lxterminal_process_arguments(gint argc, gchar * * argv, CommandArgument
         else if (strncmp(argument, "--profile=", 10) == 0)
         {
             arguments->profile = &argument[10];
-            profile = g_strdup_printf("-%s", arguments->profile);  /* include a leading hyphen */
+	    /* include a leading hyphen in a copy of the profile name */
+            profile_string = g_strdup_printf("-%s", arguments->profile);
         }
 
     /* --no-remote: Do not accept or send remote commands */

--- a/src/lxterminal.c
+++ b/src/lxterminal.c
@@ -120,6 +120,7 @@ static gchar usage_display[] = {
     "    --tabs=NAME[,NAME[,NAME[...]]] Set the terminal's title\n"
     "  --working-directory=DIRECTORY    Set the terminal's working directory\n"
     "  --no-remote                      Do not accept or send remote commands\n"
+    "  --profile=NAME                   Use a separate configuration profile\n"
     "  -v, --version                    Version information\n"
 };
 
@@ -1539,6 +1540,13 @@ gboolean lxterminal_process_arguments(gint argc, gchar * * argv, CommandArgument
         else if (strncmp(argument, "--working-directory=", 20) == 0)
         {
             arguments->working_directory = &argument[20];
+        }
+
+        /* --profile=<config-identifier> */
+        else if (strncmp(argument, "--profile=", 10) == 0)
+        {
+            arguments->profile = &argument[10];
+            profile = g_strdup_printf("-%s", arguments->profile);  /* include a leading hyphen */
         }
 
     /* --no-remote: Do not accept or send remote commands */

--- a/src/lxterminal.h
+++ b/src/lxterminal.h
@@ -87,6 +87,7 @@ typedef struct _command_arguments {
     char * title;               /* Value of -t, -T, --title; points into argument vector */
     char * tabs;                /* Value of --tab; points into argument vector */
     char * working_directory;           /* Value of --working-directory; points into argument vector */
+    char * profile;             /* Value of --profile; points into argument vector */
     gboolean login_shell;           /* Terminal will spawn login shells */
     gboolean no_remote;
 } CommandArguments;

--- a/src/setting.c
+++ b/src/setting.c
@@ -35,8 +35,10 @@
 /* Single copy setting*/
 Setting * setting;
 
-/* Config group identifier, empty by default */
-gchar * profile = "";
+/* Config group identifier.  Empty string by default.  If
+ * --profile=NAME is specified, will become "-NAME", for easy
+ * insertion into file and socket pathnames.  */
+gchar * profile_string = "";
 
 ColorPreset color_presets[] = {
     {
@@ -261,7 +263,7 @@ void save_setting()
 
     /* Convert GKeyFile to text and build path to configuration file. */
     gchar * file_data = g_key_file_to_data(setting->keyfile, NULL, NULL);
-    gchar * config_filename = g_strdup_printf("lxterminal%s.conf", profile);
+    gchar * config_filename = g_strdup_printf("lxterminal%s.conf", profile_string);
     gchar * config_path = g_build_filename(g_get_user_config_dir(), "lxterminal", config_filename, NULL);
 
     if ((file_data != NULL) && (config_path != NULL) && config_filename != NULL)
@@ -348,7 +350,7 @@ Setting * load_setting()
     int i;
     gchar * dir = g_build_filename(g_get_user_config_dir(), "lxterminal" , NULL);
     g_mkdir_with_parents(dir, S_IRUSR | S_IWUSR | S_IXUSR);
-    gchar * config_filename = g_strdup_printf("lxterminal%s.conf", profile);
+    gchar * config_filename = g_strdup_printf("lxterminal%s.conf", profile_string);
     gchar * user_config_path = g_build_filename(dir, config_filename, NULL);
     g_free(dir);
     g_free(config_filename);

--- a/src/setting.c
+++ b/src/setting.c
@@ -35,6 +35,9 @@
 /* Single copy setting*/
 Setting * setting;
 
+/* Config group identifier, empty by default */
+gchar * profile = "";
+
 ColorPreset color_presets[] = {
     {
         .name = "VGA",
@@ -258,9 +261,10 @@ void save_setting()
 
     /* Convert GKeyFile to text and build path to configuration file. */
     gchar * file_data = g_key_file_to_data(setting->keyfile, NULL, NULL);
-    gchar * config_path = g_build_filename(g_get_user_config_dir(), "lxterminal/lxterminal.conf", NULL);
+    gchar * config_filename = g_strdup_printf("lxterminal%s.conf", profile);
+    gchar * config_path = g_build_filename(g_get_user_config_dir(), "lxterminal", config_filename, NULL);
 
-    if ((file_data != NULL) && (config_path != NULL))
+    if ((file_data != NULL) && (config_path != NULL) && config_filename != NULL)
     {
         /* Create the file if necessary. */
         int fd = open(config_path, O_CREAT | O_WRONLY | O_TRUNC, S_IRUSR | S_IWUSR);
@@ -279,6 +283,7 @@ void save_setting()
     /* Deallocate memory. */
     g_free(file_data);
     g_free(config_path);
+    g_free(config_filename);
 }
 
 /* Deep copy settings. */
@@ -343,8 +348,10 @@ Setting * load_setting()
     int i;
     gchar * dir = g_build_filename(g_get_user_config_dir(), "lxterminal" , NULL);
     g_mkdir_with_parents(dir, S_IRUSR | S_IWUSR | S_IXUSR);
-    gchar * user_config_path = g_build_filename(dir, "lxterminal.conf", NULL);
+    gchar * config_filename = g_strdup_printf("lxterminal%s.conf", profile);
+    gchar * user_config_path = g_build_filename(dir, config_filename, NULL);
     g_free(dir);
+    g_free(config_filename);
     gchar * system_config_path = g_strdup(PACKAGE_DATA_DIR "/lxterminal/lxterminal.conf");
     gchar * config_path = user_config_path;
     

--- a/src/setting.c
+++ b/src/setting.c
@@ -35,10 +35,9 @@
 /* Single copy setting*/
 Setting * setting;
 
-/* Config group identifier.  Empty string by default.  If
- * --profile=NAME is specified, will become "-NAME", for easy
- * insertion into file and socket pathnames.  */
-gchar * profile_string = "";
+/* Config group identifier.  If --profile=NAME is specified, will
+ * become "-NAME", for easy insertion into file and socket pathnames. */
+gchar * profile_string;
 
 ColorPreset color_presets[] = {
     {
@@ -263,7 +262,7 @@ void save_setting()
 
     /* Convert GKeyFile to text and build path to configuration file. */
     gchar * file_data = g_key_file_to_data(setting->keyfile, NULL, NULL);
-    gchar * config_filename = g_strdup_printf("lxterminal%s.conf", profile_string);
+    gchar * config_filename = g_strdup_printf("lxterminal%s.conf", profile_string ? profile_string : "");
     gchar * config_path = g_build_filename(g_get_user_config_dir(), "lxterminal", config_filename, NULL);
 
     if ((file_data != NULL) && (config_path != NULL) && config_filename != NULL)
@@ -350,7 +349,7 @@ Setting * load_setting()
     int i;
     gchar * dir = g_build_filename(g_get_user_config_dir(), "lxterminal" , NULL);
     g_mkdir_with_parents(dir, S_IRUSR | S_IWUSR | S_IXUSR);
-    gchar * config_filename = g_strdup_printf("lxterminal%s.conf", profile_string);
+    gchar * config_filename = g_strdup_printf("lxterminal%s.conf", profile_string ? profile_string : "");
     gchar * user_config_path = g_build_filename(dir, config_filename, NULL);
     g_free(dir);
     g_free(config_filename);

--- a/src/setting.h
+++ b/src/setting.h
@@ -161,4 +161,5 @@ extern void print_setting();
 
 extern ColorPreset color_presets[];
 
+extern gchar * profile;
 #endif

--- a/src/setting.h
+++ b/src/setting.h
@@ -161,5 +161,5 @@ extern void print_setting();
 
 extern ColorPreset color_presets[];
 
-extern gchar * profile;
+extern gchar * profile_string;
 #endif

--- a/src/unixsocket.c
+++ b/src/unixsocket.c
@@ -61,12 +61,12 @@ static gboolean init(LXTermWindow* lxtermwin, gint argc, gchar** argv) {
 #if GLIB_CHECK_VERSION (2, 28, 0)
     gchar * socket_path = g_strdup_printf("%s/.lxterminal-socket%s-%s",
             g_get_user_runtime_dir(),
-            profile,
+            profile_string,
             gdk_display_get_name(gdk_display_get_default()));
 #else
     gchar * socket_path = g_strdup_printf("%s/.lxterminal-socket%s-%s",
             g_get_user_cache_dir(),
-            profile,
+            profile_string,
             gdk_display_get_name(gdk_display_get_default()));
 #endif
 

--- a/src/unixsocket.c
+++ b/src/unixsocket.c
@@ -59,12 +59,14 @@ static gboolean init(LXTermWindow* lxtermwin, gint argc, gchar** argv) {
 
     /* Formulate the path for the Unix domain socket. */
 #if GLIB_CHECK_VERSION (2, 28, 0)
-    gchar * socket_path = g_strdup_printf("%s/.lxterminal-socket-%s",
+    gchar * socket_path = g_strdup_printf("%s/.lxterminal-socket%s-%s",
             g_get_user_runtime_dir(),
+            profile,
             gdk_display_get_name(gdk_display_get_default()));
 #else
-    gchar * socket_path = g_strdup_printf("%s/.lxterminal-socket-%s",
+    gchar * socket_path = g_strdup_printf("%s/.lxterminal-socket%s-%s",
             g_get_user_cache_dir(),
+            profile,
             gdk_display_get_name(gdk_display_get_default()));
 #endif
 

--- a/src/unixsocket.c
+++ b/src/unixsocket.c
@@ -61,12 +61,12 @@ static gboolean init(LXTermWindow* lxtermwin, gint argc, gchar** argv) {
 #if GLIB_CHECK_VERSION (2, 28, 0)
     gchar * socket_path = g_strdup_printf("%s/.lxterminal-socket%s-%s",
             g_get_user_runtime_dir(),
-            profile_string,
+            profile_string ? profile_string : "",
             gdk_display_get_name(gdk_display_get_default()));
 #else
     gchar * socket_path = g_strdup_printf("%s/.lxterminal-socket%s-%s",
             g_get_user_cache_dir(),
-            profile_string,
+            profile_string ? profile_string : "",
             gdk_display_get_name(gdk_display_get_default()));
 #endif
 


### PR DESCRIPTION
I really like the simplicity of lxterminal's text config file -- it makes it much easier to get going on a new machine if I can just copy the config into place, rather than having to configure multiple settings via menu or dconf.  But I also have a need for several different configs (mostly font-size changes, and colors) for different styles of terminal.  So this small patch implements terminal "profiles".  It's very simple.

All instances of lxterminal invoked with the same "--profile=NAME" argument will share a config file (lxterminal-NAME.conf), and a socket (which is renamed in a similar way).

I'm happy to rework this, of course, if there are details that you'd prefer be changed.

Also, I included new versions of both lxterminal.xml and lxterminal.1, which I now realize was perhaps incorrect.